### PR TITLE
Fixing string display for browser compatibility

### DIFF
--- a/src/types/dtypes.ts
+++ b/src/types/dtypes.ts
@@ -235,7 +235,9 @@ export class DType {
   public static byteArrToString(arr: NumberArray): string {
     let result = "";
     for (let i = 0; i < arr.length; i++) {
-      result += String.fromCharCode(Number(arr[i]));
+      if (Number(arr[i]) !== 0) {
+        result += String.fromCharCode(Number(arr[i]));
+      }
     }
     return result;
   }

--- a/src/types/dtypes.ts
+++ b/src/types/dtypes.ts
@@ -235,9 +235,10 @@ export class DType {
   public static byteArrToString(arr: NumberArray): string {
     let result = "";
     for (let i = 0; i < arr.length; i++) {
-      if (Number(arr[i]) !== 0) {
-        result += String.fromCharCode(Number(arr[i]));
+      if (Number(arr[i]) === 0) {
+        break;
       }
+      result += String.fromCharCode(Number(arr[i]));
     }
     return result;
   }


### PR DESCRIPTION
Fixing the issue where strings that are derived from char array are not displayed correctly on Egde and Chrome browsers (see GitHub Issue 3).