### PR TITLE
Fixing an OPI scaling issue 

### DIFF
--- a/src/ui/widgets/Display/display.tsx
+++ b/src/ui/widgets/Display/display.tsx
@@ -25,8 +25,7 @@ const DisplayProps = {
   backgroundColor: ColorPropOpt,
   border: BorderPropOpt,
   macros: MacrosPropOpt,
-  displayHeight: StringPropOpt,
-  displayWidth: StringPropOpt,
+  scaling: StringPropOpt,
   autoZoomToFit: BoolPropOpt
 };
 
@@ -56,30 +55,10 @@ export const DisplayComponent = (
   style["overflow"] = props.overflow;
   style["height"] = "100%";
   if (props.autoZoomToFit) {
-    const heightString =
-      typeof props.displayHeight === "undefined" ? "10" : props.displayHeight;
-    const widthString =
-      typeof props.displayWidth === "undefined" ? "10" : props.displayWidth;
-    // Height and width property will take form "<num>px"
-    if (heightString.includes("px") && widthString.includes("px")) {
-      // Use the window size and display size to scale
-      const heightStrStripPx = heightString.slice(0, -2);
-      const heightNum = Number(heightStrStripPx);
-      const scaleHeightVal = window.innerHeight / heightNum;
-      const widthStrStripPx = widthString.slice(0, -2);
-      const widthNum = Number(widthStrStripPx);
-      const scaleWidthVal = window.innerWidth / widthNum;
-      let globalScale = 1;
-      if (scaleWidthVal < scaleHeightVal) {
-        globalScale = scaleWidthVal;
-      } else {
-        globalScale = scaleHeightVal;
-      }
-      if (globalScale < 1) {
-        style["transform"] = "scale(" + String(globalScale) + ")";
-        style["transformOrigin"] = "center top";
-      }
-    }
+    const internalScale =
+      typeof props.scaling === "undefined" ? "1" : props.scaling;
+    style["transform"] = "scale(" + internalScale + ")";
+    style["transformOrigin"] = "center top";
   }
   return (
     <MacroContext.Provider value={displayMacroContext}>

--- a/src/ui/widgets/Display/display.tsx
+++ b/src/ui/widgets/Display/display.tsx
@@ -69,12 +69,16 @@ export const DisplayComponent = (
       const widthStrStripPx = widthString.slice(0, -2);
       const widthNum = Number(widthStrStripPx);
       const scaleWidthVal = window.innerWidth / widthNum;
+      let globalScale = 1;
       if (scaleWidthVal < scaleHeightVal) {
-        style["transform"] = "scale(" + String(scaleWidthVal) + ")";
+        globalScale = scaleWidthVal;
       } else {
-        style["transform"] = "scale(" + String(scaleHeightVal) + ")";
+        globalScale = scaleHeightVal;
       }
-      style["transformOrigin"] = "center top";
+      if (globalScale < 1) {
+        style["transform"] = "scale(" + String(globalScale) + ")";
+        style["transformOrigin"] = "center top";
+      }
     }
   }
   return (

--- a/src/ui/widgets/EmbeddedDisplay/embeddedDisplay.tsx
+++ b/src/ui/widgets/EmbeddedDisplay/embeddedDisplay.tsx
@@ -50,6 +50,30 @@ export const EmbeddedDisplay = (
     props.position.height = props.position.height || description.height;
     props.position.width = props.position.width || description.width;
   }
+
+  let scaleFactor = "1";
+  if (description.autoZoomToFit) {
+    const heightString =
+      typeof description.position.height === "undefined"
+        ? "10"
+        : description.position.height;
+    const widthString =
+      typeof description.position.width === "undefined"
+        ? "10"
+        : description.position.width;
+    // Height and width property will take form "<num>px"
+    if (heightString.includes("px") && widthString.includes("px")) {
+      // Use the window size and display size to scale
+      const heightStrStripPx = heightString.slice(0, -2);
+      const scaleHeightVal = window.innerHeight / Number(heightStrStripPx);
+      const widthStrStripPx = widthString.slice(0, -2);
+      const scaleWidthVal = window.innerWidth / Number(widthStrStripPx);
+      const minScaleFactor = Math.min(scaleWidthVal, scaleHeightVal);
+      scaleFactor = String(minScaleFactor);
+      // Scale the flexcontainer height to fill window
+      props.position.height = String(window.innerHeight) + "px";
+    }
+  }
   let component: JSX.Element;
   try {
     component = widgetDescriptionToComponent({
@@ -60,8 +84,7 @@ export const EmbeddedDisplay = (
         props.border ?? new Border(BorderStyle.Line, new Color("white"), 0),
       overflow: props.scroll ? "scroll" : "hidden",
       children: [description],
-      displayHeight: description.position.height,
-      displayWidth: description.position.width,
+      scaling: scaleFactor,
       autoZoomToFit: description.autoZoomToFit
     });
   } catch (e) {


### PR DESCRIPTION
Fixing a scaling issue so that it only scales the opi display when the opi is larger than the screen resolution. If this is not the case then it can scale the OPI height to larger than has already been allocated leading to the bottom being chopped off. This should fix the issue described here: https://github.com/dls-controls/machine-status/issues/2