### PR TITLE
Adding the ability to set the background colour of embedded displays

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,2 +1,3 @@
 export { AbsolutePosition } from "./position";
 export { RelativePosition } from "./position";
+export { Color } from "./color";

--- a/src/ui/widgets/EmbeddedDisplay/embeddedDisplay.tsx
+++ b/src/ui/widgets/EmbeddedDisplay/embeddedDisplay.tsx
@@ -18,7 +18,8 @@ import {
   InferWidgetProps,
   FilePropType,
   BoolPropOpt,
-  StringPropOpt
+  StringPropOpt,
+  ColorPropOpt
 } from "../propTypes";
 import { GroupBoxComponent } from "../GroupBox/groupBox";
 import { useOpiFile } from "./useOpiFile";
@@ -28,7 +29,8 @@ const EmbeddedDisplayProps = {
   ...WidgetPropType,
   file: FilePropType,
   name: StringPropOpt,
-  scroll: BoolPropOpt
+  scroll: BoolPropOpt,
+  backgroundColor: ColorPropOpt
 };
 
 export const EmbeddedDisplay = (
@@ -55,7 +57,7 @@ export const EmbeddedDisplay = (
     component = widgetDescriptionToComponent({
       type: "display",
       position: props.position,
-      backgroundColor: new Color("rgb(200,200,200"),
+      backgroundColor: props.backgroundColor ?? new Color("rgb(200,200,200"),
       border:
         props.border ?? new Border(BorderStyle.Line, new Color("white"), 0),
       overflow: props.scroll ? "scroll" : "hidden",


### PR DESCRIPTION
The background colour of the embedded displays was hardcoded in the library class. It would be useful to be able to configure the colour from the application using the 'backgroundColor' property. This change to the library allows this.