### PR TITLE
Background color parsing

### DIFF
--- a/src/ui/widgets/EmbeddedDisplay/embeddedDisplay.tsx
+++ b/src/ui/widgets/EmbeddedDisplay/embeddedDisplay.tsx
@@ -18,7 +18,7 @@ import {
   InferWidgetProps,
   FilePropType,
   BoolPropOpt,
-  StringPropOpt,
+  StringPropOpt
 } from "../propTypes";
 import { GroupBoxComponent } from "../GroupBox/groupBox";
 import { useOpiFile } from "./useOpiFile";
@@ -28,7 +28,7 @@ const EmbeddedDisplayProps = {
   ...WidgetPropType,
   file: FilePropType,
   name: StringPropOpt,
-  scroll: BoolPropOpt,
+  scroll: BoolPropOpt
 };
 
 export const EmbeddedDisplay = (
@@ -55,7 +55,8 @@ export const EmbeddedDisplay = (
     component = widgetDescriptionToComponent({
       type: "display",
       position: props.position,
-      backgroundColor: description.backgroundColor ?? new Color("rgb(200,200,200"),
+      backgroundColor:
+        description.backgroundColor ?? new Color("rgb(200,200,200"),
       border:
         props.border ?? new Border(BorderStyle.Line, new Color("white"), 0),
       overflow: props.scroll ? "scroll" : "hidden",

--- a/src/ui/widgets/EmbeddedDisplay/embeddedDisplay.tsx
+++ b/src/ui/widgets/EmbeddedDisplay/embeddedDisplay.tsx
@@ -19,7 +19,6 @@ import {
   FilePropType,
   BoolPropOpt,
   StringPropOpt,
-  ColorPropOpt
 } from "../propTypes";
 import { GroupBoxComponent } from "../GroupBox/groupBox";
 import { useOpiFile } from "./useOpiFile";
@@ -30,7 +29,6 @@ const EmbeddedDisplayProps = {
   file: FilePropType,
   name: StringPropOpt,
   scroll: BoolPropOpt,
-  backgroundColor: ColorPropOpt
 };
 
 export const EmbeddedDisplay = (
@@ -57,7 +55,7 @@ export const EmbeddedDisplay = (
     component = widgetDescriptionToComponent({
       type: "display",
       position: props.position,
-      backgroundColor: props.backgroundColor ?? new Color("rgb(200,200,200"),
+      backgroundColor: description.backgroundColor ?? new Color("rgb(200,200,200"),
       border:
         props.border ?? new Border(BorderStyle.Line, new Color("white"), 0),
       overflow: props.scroll ? "scroll" : "hidden",


### PR DESCRIPTION
I have found a better and more flexible way of specifying the background colour of the Embedded displays. Previously I was relying on a property being set when creating the EmbeddedDisplay object, but actually I realised that it can be pulled straight from the OPI file. 
This has many advantages and in particular when loading dynamic pages (i.e. having different tabs load different OPIs). It removed the need for further complication in the application and relies purely on the parsing of the OPI file which is easily configurable.