### PR TITLE
Configure whether a cross to close a display should be shown

### DIFF
--- a/src/ui/widgets/DynamicPage/dynamicPage.tsx
+++ b/src/ui/widgets/DynamicPage/dynamicPage.tsx
@@ -12,7 +12,12 @@ import { WidgetPropType } from "../widgetProps";
 import { ActionButton } from "../ActionButton/actionButton";
 import { CLOSE_PAGE } from "../widgetActions";
 import { registerWidget } from "../register";
-import { StringProp, InferWidgetProps, BorderPropOpt } from "../propTypes";
+import {
+  StringProp,
+  InferWidgetProps,
+  BorderPropOpt,
+  StringPropOpt
+} from "../propTypes";
 import { EmbeddedDisplay } from "../EmbeddedDisplay/embeddedDisplay";
 import { Color } from "../../../types/color";
 import { RelativePosition } from "../../../types/position";
@@ -20,7 +25,8 @@ import { ExitFileContext, FileContext } from "../../../misc/fileContext";
 
 const DynamicPageProps = {
   location: StringProp,
-  border: BorderPropOpt
+  border: BorderPropOpt,
+  showCloseButton: StringPropOpt
 };
 
 // Generic display widget to put other things inside
@@ -31,6 +37,14 @@ export const DynamicPageComponent = (
   const fileContext = useContext(FileContext);
 
   const file = fileContext.pageState[props.location];
+
+  // Default behaviour is to show close button
+  let showCloseButton = true;
+  if (props.showCloseButton !== undefined) {
+    if (props.showCloseButton === "false") {
+      showCloseButton = false;
+    }
+  }
 
   if (file === undefined) {
     return (
@@ -46,7 +60,7 @@ export const DynamicPageComponent = (
         <h3>Dynamic page &quot;{props.location}&quot;: no file loaded.</h3>
       </div>
     );
-  } else {
+  } else if (showCloseButton) {
     return (
       <ExitFileContext.Provider
         value={() => fileContext.removePage(props.location)}
@@ -84,6 +98,16 @@ export const DynamicPageComponent = (
               image="/img/x.png"
             />
           </div>
+        </div>
+      </ExitFileContext.Provider>
+    );
+  } else {
+    return (
+      <ExitFileContext.Provider
+        value={() => fileContext.removePage(props.location)}
+      >
+        <div style={style}>
+          <EmbeddedDisplay file={file} position={new RelativePosition()} />
         </div>
       </ExitFileContext.Provider>
     );


### PR DESCRIPTION
If you load a display from an action button using the 'OPEN_PAGE' action, then the page gets loaded as a dynamicPage which subsequently creates an EmbeddedDisplay. By default this dynamicPage will have a cross in the corner which will close the current EmbeddedDisplay. 
In some cases I do not think this is the required behaviour, i.e. I would expect to open a view and that would be what is displayed on that page. Then if I select another button it would load a different page. I don't think there should be the option to close it as it is a little confusing.
I have added the ability to configure whether this close button is available on a dynamicPage. I have left the default behaviour to be that it is shown (so as to not change the behaviour in other instances). However adding the '`showCloseButton=false`' to the json file will cause the close button not to be shown.