### PR TITLE
Show line breaks

### DIFF
--- a/src/ui/widgets/Label/label.tsx
+++ b/src/ui/widgets/Label/label.tsx
@@ -86,7 +86,6 @@ export const LabelComponent = (
 
   if (wrapWords) {
     style["wordBreak"] = "break-word";
-    style["whiteSpace"] = "pre-line";
   }
 
   // Simple component to display text - defaults to black text and dark grey background

--- a/src/ui/widgets/Label/label.tsx
+++ b/src/ui/widgets/Label/label.tsx
@@ -86,7 +86,7 @@ export const LabelComponent = (
 
   if (wrapWords) {
     style["wordBreak"] = "break-word";
-    style["whiteSpace"] = "normal";
+    style["whiteSpace"] = "pre-line";
   }
 
   // Simple component to display text - defaults to black text and dark grey background


### PR DESCRIPTION
An issue was reported where line breaks in char arrays were not being displayed. I realised that this was because the 'white-spaces' property of the css was incorrectly being set internally which is not actually necessary to perform word-wrapping and was causing the line breaks to be ignored. Removing this property and relying on the underlying css configuration fixes this issue,