### PR TITLE
Fix duplicate graphql subscriptions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.12",
       "license": "ISC",
       "dependencies": {
+        "apollo-link-retry": "^2.2.16",
         "loglevel": "^1.8.0",
         "redux": "^4.1.2"
       },
@@ -3866,6 +3867,11 @@
       "integrity": "sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw==",
       "dev": true
     },
+    "node_modules/@types/zen-observable": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.0.tgz",
+      "integrity": "sha512-te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg=="
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "4.33.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.33.0.tgz",
@@ -4464,6 +4470,92 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/apollo-link": {
+      "version": "1.2.14",
+      "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.14.tgz",
+      "integrity": "sha512-p67CMEFP7kOG1JZ0ZkYZwRDa369w5PIjtMjvrQd/HnIV8FRsHRqLqK+oAZQnFa1DDdZtOtHTi+aMIW6EatC2jg==",
+      "dependencies": {
+        "apollo-utilities": "^1.3.0",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.9.3",
+        "zen-observable-ts": "^0.8.21"
+      },
+      "peerDependencies": {
+        "graphql": "^0.11.3 || ^0.12.3 || ^0.13.0 || ^14.0.0 || ^15.0.0"
+      }
+    },
+    "node_modules/apollo-link-retry": {
+      "version": "2.2.16",
+      "resolved": "https://registry.npmjs.org/apollo-link-retry/-/apollo-link-retry-2.2.16.tgz",
+      "integrity": "sha512-7F9+meFAz4dw5gtgtLsRFqJW6QzNOhTzt5R5Hsy+yFhkTW9LddgYO7gxN9n7RN/7Ouosh3TcpUkdHs2laC+0sA==",
+      "dependencies": {
+        "@types/zen-observable": "0.8.0",
+        "apollo-link": "^1.2.14",
+        "tslib": "^1.9.3"
+      }
+    },
+    "node_modules/apollo-link-retry/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/apollo-link/node_modules/ts-invariant": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.4.4.tgz",
+      "integrity": "sha512-uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==",
+      "dependencies": {
+        "tslib": "^1.9.3"
+      }
+    },
+    "node_modules/apollo-link/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/apollo-link/node_modules/zen-observable-ts": {
+      "version": "0.8.21",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.21.tgz",
+      "integrity": "sha512-Yj3yXweRc8LdRMrCC8nIc4kkjWecPAUVh0TI0OUrWXx6aX790vLcDlWca6I4vsyCGH3LpWxq0dJRcMOFoVqmeg==",
+      "dependencies": {
+        "tslib": "^1.9.3",
+        "zen-observable": "^0.8.0"
+      }
+    },
+    "node_modules/apollo-utilities": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.3.4.tgz",
+      "integrity": "sha512-pk2hiWrCXMAy2fRPwEyhvka+mqwzeP60Jr1tRYi5xru+3ko94HI9o6lK0CT33/w4RDlxWchmdhDCrvdr+pHCig==",
+      "dependencies": {
+        "@wry/equality": "^0.1.2",
+        "fast-json-stable-stringify": "^2.0.0",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.10.0"
+      },
+      "peerDependencies": {
+        "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
+      }
+    },
+    "node_modules/apollo-utilities/node_modules/@wry/equality": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.1.11.tgz",
+      "integrity": "sha512-mwEVBDUVODlsQQ5dfuLUS5/Tf7jqUKyhKYHmVi4fPB6bDMOfWvUPJmKgS1Z7Za/sOI3vzWt4+O7yCiL/70MogA==",
+      "dependencies": {
+        "tslib": "^1.9.3"
+      }
+    },
+    "node_modules/apollo-utilities/node_modules/ts-invariant": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.4.4.tgz",
+      "integrity": "sha512-uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==",
+      "dependencies": {
+        "tslib": "^1.9.3"
+      }
+    },
+    "node_modules/apollo-utilities/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/aproba": {
       "version": "1.2.0",
@@ -9607,8 +9699,7 @@
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
@@ -10419,13 +10510,12 @@
       "dev": true
     },
     "node_modules/graphql": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.3.0.tgz",
-      "integrity": "sha512-xm+ANmA16BzCT5pLjuXySbQVFwH3oJctUVdy81w1sV0vBU0KgDdBGtxQOUd5zqOBk/JayAFeG8Dlmeq74rjm/A==",
-      "dev": true,
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
+      "integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==",
       "peer": true,
       "engines": {
-        "node": "^12.22.0 || ^14.16.0 || >=16.0.0"
+        "node": ">= 10.x"
       }
     },
     "node_modules/graphql-tag": {
@@ -26516,8 +26606,7 @@
     "node_modules/zen-observable": {
       "version": "0.8.15",
       "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
-      "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==",
-      "dev": true
+      "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ=="
     },
     "node_modules/zen-observable-ts": {
       "version": "1.2.3",
@@ -29351,6 +29440,11 @@
       "integrity": "sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw==",
       "dev": true
     },
+    "@types/zen-observable": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.0.tgz",
+      "integrity": "sha512-te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg=="
+    },
     "@typescript-eslint/eslint-plugin": {
       "version": "4.33.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.33.0.tgz",
@@ -29804,6 +29898,92 @@
       "requires": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
+      }
+    },
+    "apollo-link": {
+      "version": "1.2.14",
+      "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.14.tgz",
+      "integrity": "sha512-p67CMEFP7kOG1JZ0ZkYZwRDa369w5PIjtMjvrQd/HnIV8FRsHRqLqK+oAZQnFa1DDdZtOtHTi+aMIW6EatC2jg==",
+      "requires": {
+        "apollo-utilities": "^1.3.0",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.9.3",
+        "zen-observable-ts": "^0.8.21"
+      },
+      "dependencies": {
+        "ts-invariant": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.4.4.tgz",
+          "integrity": "sha512-uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==",
+          "requires": {
+            "tslib": "^1.9.3"
+          }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        },
+        "zen-observable-ts": {
+          "version": "0.8.21",
+          "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.21.tgz",
+          "integrity": "sha512-Yj3yXweRc8LdRMrCC8nIc4kkjWecPAUVh0TI0OUrWXx6aX790vLcDlWca6I4vsyCGH3LpWxq0dJRcMOFoVqmeg==",
+          "requires": {
+            "tslib": "^1.9.3",
+            "zen-observable": "^0.8.0"
+          }
+        }
+      }
+    },
+    "apollo-link-retry": {
+      "version": "2.2.16",
+      "resolved": "https://registry.npmjs.org/apollo-link-retry/-/apollo-link-retry-2.2.16.tgz",
+      "integrity": "sha512-7F9+meFAz4dw5gtgtLsRFqJW6QzNOhTzt5R5Hsy+yFhkTW9LddgYO7gxN9n7RN/7Ouosh3TcpUkdHs2laC+0sA==",
+      "requires": {
+        "@types/zen-observable": "0.8.0",
+        "apollo-link": "^1.2.14",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "apollo-utilities": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.3.4.tgz",
+      "integrity": "sha512-pk2hiWrCXMAy2fRPwEyhvka+mqwzeP60Jr1tRYi5xru+3ko94HI9o6lK0CT33/w4RDlxWchmdhDCrvdr+pHCig==",
+      "requires": {
+        "@wry/equality": "^0.1.2",
+        "fast-json-stable-stringify": "^2.0.0",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.10.0"
+      },
+      "dependencies": {
+        "@wry/equality": {
+          "version": "0.1.11",
+          "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.1.11.tgz",
+          "integrity": "sha512-mwEVBDUVODlsQQ5dfuLUS5/Tf7jqUKyhKYHmVi4fPB6bDMOfWvUPJmKgS1Z7Za/sOI3vzWt4+O7yCiL/70MogA==",
+          "requires": {
+            "tslib": "^1.9.3"
+          }
+        },
+        "ts-invariant": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.4.4.tgz",
+          "integrity": "sha512-uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==",
+          "requires": {
+            "tslib": "^1.9.3"
+          }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
       }
     },
     "aproba": {
@@ -33866,8 +34046,7 @@
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -34504,10 +34683,9 @@
       "dev": true
     },
     "graphql": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.3.0.tgz",
-      "integrity": "sha512-xm+ANmA16BzCT5pLjuXySbQVFwH3oJctUVdy81w1sV0vBU0KgDdBGtxQOUd5zqOBk/JayAFeG8Dlmeq74rjm/A==",
-      "dev": true,
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
+      "integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==",
       "peer": true
     },
     "graphql-tag": {
@@ -47120,8 +47298,7 @@
     "zen-observable": {
       "version": "0.8.15",
       "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
-      "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==",
-      "dev": true
+      "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ=="
     },
     "zen-observable-ts": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "url": "https://github.com/dls-controls/cs-web-lib.git"
   },
   "dependencies": {
+    "apollo-link-retry": "^2.2.16",
     "loglevel": "^1.8.0",
     "redux": "^4.1.2"
   },

--- a/src/connection/coniql.test.ts
+++ b/src/connection/coniql.test.ts
@@ -66,6 +66,7 @@ describe("ConiqlPlugin", (): void => {
     ApolloClient.prototype.subscribe = jest.fn(
       (_): MockObservable => new MockObservable({ float: 42 })
     ) as jest.Mock;
+    Object.defineProperty(cp, "websocketClientConnected", { get: () => true });
     cp.subscribe("hello", { string: true });
     expect(ApolloClient.prototype.subscribe).toHaveBeenCalled();
     expect(mockValUpdate).toHaveBeenCalledWith(
@@ -87,6 +88,7 @@ describe("ConiqlPlugin", (): void => {
           }
         )
     ) as jest.Mock;
+    Object.defineProperty(cp, "websocketClientConnected", { get: () => true });
     cp.subscribe("hello", { string: true });
     expect(ApolloClient.prototype.subscribe).toHaveBeenCalled();
     expect(mockValUpdate).toHaveBeenCalledWith(
@@ -110,6 +112,7 @@ describe("ConiqlPlugin", (): void => {
           }
         })
     ) as jest.Mock;
+    Object.defineProperty(cp, "websocketClientConnected", { get: () => true });
     cp.subscribe("hello", { string: true });
     expect(ApolloClient.prototype.subscribe).toHaveBeenCalled();
     const calls = mockValUpdate.mock.calls;
@@ -117,6 +120,18 @@ describe("ConiqlPlugin", (): void => {
     const [pv, value] = mockValUpdate.mock.calls[0];
     expect(pv).toBe("hello");
     expect(value.time?.datetime?.getFullYear()).toBe(2017);
+  });
+
+  it("only subscribe when websocket connected", (): void => {
+    ApolloClient.prototype.subscribe = jest.fn(
+      (_): MockObservable => new MockObservable({ float: 42 })
+    ) as jest.Mock;
+    Object.defineProperty(cp, "websocketClientConnected", { get: () => false });
+    cp.subscribe("hello", { string: true });
+    expect(ApolloClient.prototype.subscribe).toBeCalledTimes(0);
+    Object.defineProperty(cp, "websocketClientConnected", { get: () => true });
+    cp.subscribe("hello", { string: true });
+    expect(ApolloClient.prototype.subscribe).toBeCalledTimes(1);
   });
 
   it("queries with device query", (): void => {

--- a/src/connection/coniql.test.ts
+++ b/src/connection/coniql.test.ts
@@ -66,7 +66,6 @@ describe("ConiqlPlugin", (): void => {
     ApolloClient.prototype.subscribe = jest.fn(
       (_): MockObservable => new MockObservable({ float: 42 })
     ) as jest.Mock;
-    Object.defineProperty(cp, "websocketClientConnected", { get: () => true });
     cp.subscribe("hello", { string: true });
     expect(ApolloClient.prototype.subscribe).toHaveBeenCalled();
     expect(mockValUpdate).toHaveBeenCalledWith(
@@ -88,7 +87,6 @@ describe("ConiqlPlugin", (): void => {
           }
         )
     ) as jest.Mock;
-    Object.defineProperty(cp, "websocketClientConnected", { get: () => true });
     cp.subscribe("hello", { string: true });
     expect(ApolloClient.prototype.subscribe).toHaveBeenCalled();
     expect(mockValUpdate).toHaveBeenCalledWith(
@@ -112,7 +110,6 @@ describe("ConiqlPlugin", (): void => {
           }
         })
     ) as jest.Mock;
-    Object.defineProperty(cp, "websocketClientConnected", { get: () => true });
     cp.subscribe("hello", { string: true });
     expect(ApolloClient.prototype.subscribe).toHaveBeenCalled();
     const calls = mockValUpdate.mock.calls;
@@ -120,18 +117,6 @@ describe("ConiqlPlugin", (): void => {
     const [pv, value] = mockValUpdate.mock.calls[0];
     expect(pv).toBe("hello");
     expect(value.time?.datetime?.getFullYear()).toBe(2017);
-  });
-
-  it("only subscribe when websocket connected", (): void => {
-    ApolloClient.prototype.subscribe = jest.fn(
-      (_): MockObservable => new MockObservable({ float: 42 })
-    ) as jest.Mock;
-    Object.defineProperty(cp, "websocketClientConnected", { get: () => false });
-    cp.subscribe("hello", { string: true });
-    expect(ApolloClient.prototype.subscribe).toBeCalledTimes(0);
-    Object.defineProperty(cp, "websocketClientConnected", { get: () => true });
-    cp.subscribe("hello", { string: true });
-    expect(ApolloClient.prototype.subscribe).toBeCalledTimes(1);
   });
 
   it("queries with device query", (): void => {


### PR DESCRIPTION
This fixes the issue described in https://github.com/dls-controls/cs-web-lib/issues/11. 
Two issues have been addressed: trying to subscribe before the websocket client is connected and the unsubscribe not fully removing the subscription from the websocket (see [comment](https://github.com/dls-controls/cs-web-lib/issues/11#issuecomment-1161558094) in issue for more details).