### PR TITLE
Fix a bug when scaling display causing cutoff

### DIFF
--- a/src/ui/widgets/EmbeddedDisplay/embeddedDisplay.tsx
+++ b/src/ui/widgets/EmbeddedDisplay/embeddedDisplay.tsx
@@ -71,7 +71,9 @@ export const EmbeddedDisplay = (
       const minScaleFactor = Math.min(scaleWidthVal, scaleHeightVal);
       scaleFactor = String(minScaleFactor);
       // Scale the flexcontainer height to fill window
-      props.position.height = String(window.innerHeight) + "px";
+      if (window.innerHeight > Number(heightStrStripPx)) {
+        props.position.height = String(window.innerHeight) + "px";
+      }
     }
   }
   let component: JSX.Element;


### PR DESCRIPTION
This was a bug that was missed in the PR https://github.com/dls-controls/cs-web-lib/pull/3. The embedded display height was being cropped to the screen resolution height in some cases, which is not desired behaviour. The display should only be cropped if it is larger than the screen height. I have added this check in this fix.

