### PR TITLE
Add plot widget

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,18 @@
 {
   "name": "@dls-controls/cs-web-lib",
-  "version": "0.1.13",
+  "version": "0.1.15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dls-controls/cs-web-lib",
-      "version": "0.1.13",
+      "version": "0.1.15",
       "license": "ISC",
       "dependencies": {
         "apollo-link-retry": "^2.2.16",
         "loglevel": "^1.8.0",
+        "plotly.js": "^2.17.1",
+        "react-plotly.js": "^2.6.0",
         "redux": "^4.1.2"
       },
       "devDependencies": {
@@ -2088,6 +2090,22 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "node_modules/@choojs/findup": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@choojs/findup/-/findup-0.2.1.tgz",
+      "integrity": "sha512-YstAqNb0MCN8PjdLCDfRsBcGVRN41f3vgLvaI0IrIcBp4AqILRSS0DeWNGkicC+f/zRIPJLc+9RURVSepwvfBw==",
+      "dependencies": {
+        "commander": "^2.15.1"
+      },
+      "bin": {
+        "findup": "bin/findup.js"
+      }
+    },
+    "node_modules/@choojs/findup/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+    },
     "node_modules/@cnakazawa/watch": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.4.tgz",
@@ -2719,6 +2737,81 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@mapbox/geojson-rewind": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-rewind/-/geojson-rewind-0.5.2.tgz",
+      "integrity": "sha512-tJaT+RbYGJYStt7wI3cq4Nl4SXxG8W7JDG5DMJu97V25RnbNg3QtQtf+KD+VLjNpWKYsRvXDNmNrBgEETr1ifA==",
+      "dependencies": {
+        "get-stream": "^6.0.1",
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "geojson-rewind": "geojson-rewind"
+      }
+    },
+    "node_modules/@mapbox/geojson-rewind/node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@mapbox/geojson-types": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-types/-/geojson-types-1.0.2.tgz",
+      "integrity": "sha512-e9EBqHHv3EORHrSfbR9DqecPNn+AmuAoQxV6aL8Xu30bJMJR1o8PZLZzpk1Wq7/NfCbuhmakHTPYRhoqLsXRnw=="
+    },
+    "node_modules/@mapbox/jsonlint-lines-primitives": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
+      "integrity": "sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@mapbox/mapbox-gl-supported": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-1.5.0.tgz",
+      "integrity": "sha512-/PT1P6DNf7vjEEiPkVIRJkvibbqWtqnyGaBz3nfRdcxclNSnSdaLU5tfAgcD7I8Yt5i+L19s406YLl1koLnLbg==",
+      "peerDependencies": {
+        "mapbox-gl": ">=0.32.1 <2.0.0"
+      }
+    },
+    "node_modules/@mapbox/point-geometry": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
+      "integrity": "sha512-6j56HdLTwWGO0fJPlrZtdU/B13q8Uwmo18Ck2GnGgN9PCFyKTZ3UbXeEdRFh18i9XQ92eH2VdtpJHpBD3aripQ=="
+    },
+    "node_modules/@mapbox/tiny-sdf": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-1.2.5.tgz",
+      "integrity": "sha512-cD8A/zJlm6fdJOk6DqPUV8mcpyJkRz2x2R+/fYcWDYG3oWbG7/L7Yl/WqQ1VZCjnL9OTIMAn6c+BC5Eru4sQEw=="
+    },
+    "node_modules/@mapbox/unitbezier": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.0.tgz",
+      "integrity": "sha512-HPnRdYO0WjFjRTSwO3frz1wKaU649OBFPX3Zo/2WZvuRi6zMiRGui8SnPQiQABgqCf8YikDe5t3HViTVw1WUzA=="
+    },
+    "node_modules/@mapbox/vector-tile": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-1.3.1.tgz",
+      "integrity": "sha512-MCEddb8u44/xfQ3oD+Srl/tNcQoqTw3goGk2oLsrFxOTc3dUp+kAnby3PvAeeBYSMSjSPD1nd1AJA6W49WnoUw==",
+      "dependencies": {
+        "@mapbox/point-geometry": "~0.1.0"
+      }
+    },
+    "node_modules/@mapbox/whoots-js": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz",
+      "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@material-ui/core": {
       "version": "4.12.3",
       "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.12.3.tgz",
@@ -2927,6 +3020,49 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@plotly/d3": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@plotly/d3/-/d3-3.8.0.tgz",
+      "integrity": "sha512-L10iHgzvw3uSic/nQpYehlNzxUQvImwms5U7S95pJAEhrllzkrdQNy1Mc5DW9ab881Yr4fh300gJztKXWZDfkQ=="
+    },
+    "node_modules/@plotly/d3-sankey": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@plotly/d3-sankey/-/d3-sankey-0.7.2.tgz",
+      "integrity": "sha512-2jdVos1N3mMp3QW0k2q1ph7Gd6j5PY1YihBrwpkFnKqO+cqtZq3AdEYUeSGXMeLsBDQYiqTVcihYfk8vr5tqhw==",
+      "dependencies": {
+        "d3-array": "1",
+        "d3-collection": "1",
+        "d3-shape": "^1.2.0"
+      }
+    },
+    "node_modules/@plotly/d3-sankey-circular": {
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@plotly/d3-sankey-circular/-/d3-sankey-circular-0.33.1.tgz",
+      "integrity": "sha512-FgBV1HEvCr3DV7RHhDsPXyryknucxtfnLwPtCKKxdolKyTFYoLX/ibEfX39iFYIL7DYbVeRtP43dbFcrHNE+KQ==",
+      "dependencies": {
+        "d3-array": "^1.2.1",
+        "d3-collection": "^1.0.4",
+        "d3-shape": "^1.2.0",
+        "elementary-circuits-directed-graph": "^1.0.4"
+      }
+    },
+    "node_modules/@plotly/point-cluster": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@plotly/point-cluster/-/point-cluster-3.1.9.tgz",
+      "integrity": "sha512-MwaI6g9scKf68Orpr1pHZ597pYx9uP8UEFXLPbsCmuw3a84obwz6pnMXGc90VhgDNeNiLEdlmuK7CPo+5PIxXw==",
+      "dependencies": {
+        "array-bounds": "^1.0.1",
+        "binary-search-bounds": "^2.0.4",
+        "clamp": "^1.0.1",
+        "defined": "^1.0.0",
+        "dtype": "^2.0.0",
+        "flatten-vertex-data": "^1.0.2",
+        "is-obj": "^1.0.1",
+        "math-log2": "^1.0.1",
+        "parse-rect": "^1.2.0",
+        "pick-by-alias": "^1.2.0"
       }
     },
     "node_modules/@rollup/plugin-commonjs": {
@@ -3423,6 +3559,61 @@
       "dev": true,
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/@turf/area": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/area/-/area-6.5.0.tgz",
+      "integrity": "sha512-xCZdiuojokLbQ+29qR6qoMD89hv+JAgWjLrwSEWL+3JV8IXKeNFl6XkEJz9HGkVpnXvQKJoRz4/liT+8ZZ5Jyg==",
+      "dependencies": {
+        "@turf/helpers": "^6.5.0",
+        "@turf/meta": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/bbox": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-6.5.0.tgz",
+      "integrity": "sha512-RBbLaao5hXTYyyg577iuMtDB8ehxMlUqHEJiMs8jT1GHkFhr6sYre3lmLsPeYEi/ZKj5TP5tt7fkzNdJ4GIVyw==",
+      "dependencies": {
+        "@turf/helpers": "^6.5.0",
+        "@turf/meta": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/centroid": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-6.5.0.tgz",
+      "integrity": "sha512-MwE1oq5E3isewPprEClbfU5pXljIK/GUOMbn22UM3IFPDJX0KeoyLNwghszkdmFp/qMGL/M13MMWvU+GNLXP/A==",
+      "dependencies": {
+        "@turf/helpers": "^6.5.0",
+        "@turf/meta": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/helpers": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.5.0.tgz",
+      "integrity": "sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw==",
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/meta": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.5.0.tgz",
+      "integrity": "sha512-RrArvtsV0vdsCBegoBtOalgdSOfkBrTJ07VkpiCnq/491W67hnMWmDu7e6Ztw0C3WldRYTXkg3SumfdzZxLBHA==",
+      "dependencies": {
+        "@turf/helpers": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
       }
     },
     "node_modules/@types/aria-query": {
@@ -4258,6 +4449,11 @@
       "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
       "dev": true
     },
+    "node_modules/abs-svg-path": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/abs-svg-path/-/abs-svg-path-0.1.1.tgz",
+      "integrity": "sha512-d8XPSGjfyzlXC3Xx891DJRyZfqk5JU0BJrDQcsWomFIV1/BIzPW5HDH5iDdWpqWaav0YVIEzT1RHTwWr0FFshA=="
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -4275,7 +4471,6 @@
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
-      "dev": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4391,6 +4586,11 @@
       "peerDependencies": {
         "ajv": "^6.9.1"
       }
+    },
+    "node_modules/almost-equal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/almost-equal/-/almost-equal-1.1.0.tgz",
+      "integrity": "sha512-0V/PkoculFl5+0Lp47JoxUcO0xSxhIBvm+BxHdD/OgXNmdRpRHCFnKVuUoWyS9EzQP+otSGv0m9Lb4yVkQBn2A=="
     },
     "node_modules/alphanum-sort": {
       "version": "1.0.2",
@@ -4604,7 +4804,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
       "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4614,6 +4813,19 @@
       "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
       "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/array-bounds": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/array-bounds/-/array-bounds-1.0.1.tgz",
+      "integrity": "sha512-8wdW3ZGk6UjMPJx/glyEt0sLzzwAE1bhToPsO1W2pbpR2gULyxe3BjSiuJFheP50T/GgODVPz2fuMUmIywt8cQ=="
+    },
+    "node_modules/array-find-index": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+      "integrity": "sha512-M1HQyIXcBGtVywBt8WVdim+lrNaK7VHp99Qt5pSNziXznKHViIBbXWtfRTpEFpF/c4FdfxNAsCCwPp5phBYJtw==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4642,6 +4854,24 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/array-normalize": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/array-normalize/-/array-normalize-1.1.4.tgz",
+      "integrity": "sha512-fCp0wKFLjvSPmCn4F5Tiw4M3lpMZoHlCjfcs7nNzuj3vqQQ1/a8cgB9DXcpDSn18c+coLnaW7rqfcYCvKbyJXg==",
+      "dependencies": {
+        "array-bounds": "^1.0.0"
+      }
+    },
+    "node_modules/array-range": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/array-range/-/array-range-1.0.1.tgz",
+      "integrity": "sha512-shdaI1zT3CVNL2hnx9c0JMc0ZogGaxDs5e85akgHWKYa0yVbIyp06Ind3dVkTj/uuFrzaHBOyqFzo+VV6aXgtA=="
+    },
+    "node_modules/array-rearrange": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/array-rearrange/-/array-rearrange-2.2.2.tgz",
+      "integrity": "sha512-UfobP5N12Qm4Qu4fwLDIi2v6+wZsSf6snYSxAMeKhrh37YGnNWZPRmVEKc/2wfms53TLQnzfpG8wCx2Y/6NG1w=="
     },
     "node_modules/array-union": {
       "version": "2.1.0",
@@ -4833,6 +5063,11 @@
       "engines": {
         "node": ">= 4.5.0"
       }
+    },
+    "node_modules/atob-lite": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-2.0.0.tgz",
+      "integrity": "sha512-LEeSAWeh2Gfa2FtlQE1shxQ8zi5F9GHarrGKz08TMdODD5T4eH6BMsvtnhbWZ+XQn+Gb6om/917ucvRu7l7ukw=="
     },
     "node_modules/autoprefixer": {
       "version": "9.8.8",
@@ -5345,6 +5580,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/binary-search-bounds": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-2.0.5.tgz",
+      "integrity": "sha512-H0ea4Fd3lS1+sTEB2TgcLoK21lLhwEJzlQv3IN47pJS976Gx4zoWe0ak3q+uYh60ppQxg9F16Ri4tS1sfD4+jA=="
+    },
     "node_modules/bindings": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
@@ -5353,6 +5593,25 @@
       "optional": true,
       "dependencies": {
         "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bit-twiddle": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bit-twiddle/-/bit-twiddle-1.0.2.tgz",
+      "integrity": "sha512-B9UhK0DKFZhoTFcfvAzhqsjStvGJp9vYWf3+6SNTtdSQnvIgfkHbgHrg/e4+TH71N2GDu8tpmCVoyfrL1d7ntA=="
+    },
+    "node_modules/bitmap-sdf": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/bitmap-sdf/-/bitmap-sdf-1.0.4.tgz",
+      "integrity": "sha512-1G3U4n5JE6RAiALMxu0p1XmeZkTeCwGKykzsLTCqVzfSDaN6S7fKnkIkfejogz+iwqBWc0UYAIKnKHNN7pSfDg=="
+    },
+    "node_modules/bl": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
+      "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
+      "dependencies": {
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
       }
     },
     "node_modules/bluebird": {
@@ -5619,8 +5878,7 @@
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
     "node_modules/buffer-indexof": {
       "version": "1.1.1",
@@ -5827,6 +6085,14 @@
         "url": "https://opencollective.com/browserslist"
       }
     },
+    "node_modules/canvas-fit": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/canvas-fit/-/canvas-fit-1.5.0.tgz",
+      "integrity": "sha512-onIcjRpz69/Hx5bB5HGbYKUF2uC6QT6Gp+pfpGm3A7mPfcluSLV5v4Zu+oflDUwLdUw0rLIBhUbi0v8hM4FJQQ==",
+      "dependencies": {
+        "element-size": "^1.1.1"
+      }
+    },
     "node_modules/capture-exit": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-2.0.0.tgz",
@@ -5955,6 +6221,11 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-0.6.0.tgz",
       "integrity": "sha512-uc2Vix1frTfnuzxxu1Hp4ktSvM3QaI4oXl4ZUqL1wjTu/BGki9TrCWoqLTg/drR1KwAEarXuRFCG2Svr1GxPFw==",
       "dev": true
+    },
+    "node_modules/clamp": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/clamp/-/clamp-1.0.1.tgz",
+      "integrity": "sha512-kgMuFyE78OC6Dyu3Dy7vcx4uy97EIbVxJB/B0eJ3bUNAkwdNcxYzgKltnyADiYwsR7SEqkkUPsEUT//OVS6XMA=="
     },
     "node_modules/class-utils": {
       "version": "0.3.6",
@@ -6269,6 +6540,14 @@
         "color-string": "^1.6.0"
       }
     },
+    "node_modules/color-alpha": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/color-alpha/-/color-alpha-1.0.4.tgz",
+      "integrity": "sha512-lr8/t5NPozTSqli+duAN+x+no/2WaKTeWvxhHGN+aXT6AJ8vPlzLa7UriyjWak0pSC2jHol9JgjBYnnHsGha9A==",
+      "dependencies": {
+        "color-parse": "^1.3.8"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -6281,11 +6560,57 @@
         "node": ">=7.0.0"
       }
     },
+    "node_modules/color-id": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/color-id/-/color-id-1.1.0.tgz",
+      "integrity": "sha512-2iRtAn6dC/6/G7bBIo0uupVrIne1NsQJvJxZOBCzQOfk7jRq97feaDZ3RdzuHakRXXnHGNwglto3pqtRx1sX0g==",
+      "dependencies": {
+        "clamp": "^1.0.1"
+      }
+    },
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/color-normalize": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/color-normalize/-/color-normalize-1.5.0.tgz",
+      "integrity": "sha512-rUT/HDXMr6RFffrR53oX3HGWkDOP9goSAQGBkUaAYKjOE2JxozccdGyufageWDlInRAjm/jYPrf/Y38oa+7obw==",
+      "dependencies": {
+        "clamp": "^1.0.1",
+        "color-rgba": "^2.1.1",
+        "dtype": "^2.0.0"
+      }
+    },
+    "node_modules/color-parse": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-1.3.8.tgz",
+      "integrity": "sha512-1Y79qFv0n1xair3lNMTNeoFvmc3nirMVBij24zbs1f13+7fPpQClMg5b4AuKXLt3szj7BRlHMCXHplkce6XlmA==",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "defined": "^1.0.0",
+        "is-plain-obj": "^1.1.0"
+      }
+    },
+    "node_modules/color-rgba": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/color-rgba/-/color-rgba-2.1.1.tgz",
+      "integrity": "sha512-VaX97wsqrMwLSOR6H7rU1Doa2zyVdmShabKrPEIFywLlHoibgD3QW9Dw6fSqM4+H/LfjprDNAUUW31qEQcGzNw==",
+      "dependencies": {
+        "clamp": "^1.0.1",
+        "color-parse": "^1.3.8",
+        "color-space": "^1.14.6"
+      }
+    },
+    "node_modules/color-space": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/color-space/-/color-space-1.16.0.tgz",
+      "integrity": "sha512-A6WMiFzunQ8KEPFmj02OnnoUnqhmSaHaZ/0LVFcPTdlvm8+3aMJ5x1HRHy3bDHPkovkf4sS0f4wsVvwk71fKkg==",
+      "dependencies": {
+        "hsluv": "^0.0.3",
+        "mumath": "^3.3.4"
+      }
     },
     "node_modules/color-string": {
       "version": "1.9.0",
@@ -6414,6 +6739,18 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
+    "node_modules/compute-dims": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/compute-dims/-/compute-dims-1.1.0.tgz",
+      "integrity": "sha512-YHMiIKjH/8Eom8zATk3g8/lH3HxGCZcVQyEfEoVrfWI7od/WRpTgRGShnei3jArYSx77mQqPxZNokjGHCdLfxg==",
+      "dependencies": {
+        "utils-copy": "^1.0.0",
+        "validate.io-array": "^1.0.6",
+        "validate.io-matrix-like": "^1.0.2",
+        "validate.io-ndarray-like": "^1.0.0",
+        "validate.io-positive-integer": "^1.0.0"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -6424,7 +6761,6 @@
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-      "dev": true,
       "engines": [
         "node >= 0.8"
       ],
@@ -6473,6 +6809,16 @@
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
       "integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==",
       "dev": true
+    },
+    "node_modules/const-max-uint32": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/const-max-uint32/-/const-max-uint32-1.0.2.tgz",
+      "integrity": "sha512-T8/9bffg5RThuejasJWrwqxs3Q0fsJvyl7/33IB6svroD8JC93E7X60AuuOnDE8RlP6Jlb5FxmlrVDpl9KiU2Q=="
+    },
+    "node_modules/const-pinf-float64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/const-pinf-float64/-/const-pinf-float64-1.0.0.tgz",
+      "integrity": "sha512-wfs+V4HdSN7C3CWJWR7hVa24yTPn3mDJthwhRIObZBh6UjTjkUMUrCP3UrNGozB/HjTpcScnGXtQUNa+yjsIJQ=="
     },
     "node_modules/constants-browserify": {
       "version": "1.0.0",
@@ -6628,8 +6974,7 @@
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "dev": true
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "node_modules/cosmiconfig": {
       "version": "7.0.1",
@@ -6646,6 +6991,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/country-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/country-regex/-/country-regex-1.1.0.tgz",
+      "integrity": "sha512-iSPlClZP8vX7MC3/u6s3lrDuoQyhQukh5LyABJ3hvfzbQ3Yyayd4fp04zjLnfi267B/B2FkumcWWgrbban7sSA=="
     },
     "node_modules/create-ecdh": {
       "version": "4.0.4",
@@ -6847,6 +7197,47 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/css-font": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/css-font/-/css-font-1.2.0.tgz",
+      "integrity": "sha512-V4U4Wps4dPDACJ4WpgofJ2RT5Yqwe1lEH6wlOOaIxMi0gTjdIijsc5FmxQlZ7ZZyKQkkutqqvULOp07l9c7ssA==",
+      "dependencies": {
+        "css-font-size-keywords": "^1.0.0",
+        "css-font-stretch-keywords": "^1.0.1",
+        "css-font-style-keywords": "^1.0.1",
+        "css-font-weight-keywords": "^1.0.0",
+        "css-global-keywords": "^1.0.1",
+        "css-system-font-keywords": "^1.0.0",
+        "pick-by-alias": "^1.2.0",
+        "string-split-by": "^1.0.0",
+        "unquote": "^1.1.0"
+      }
+    },
+    "node_modules/css-font-size-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-font-size-keywords/-/css-font-size-keywords-1.0.0.tgz",
+      "integrity": "sha512-Q+svMDbMlelgCfH/RVDKtTDaf5021O486ZThQPIpahnIjUkMUslC+WuOQSWTgGSrNCH08Y7tYNEmmy0hkfMI8Q=="
+    },
+    "node_modules/css-font-stretch-keywords": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/css-font-stretch-keywords/-/css-font-stretch-keywords-1.0.1.tgz",
+      "integrity": "sha512-KmugPO2BNqoyp9zmBIUGwt58UQSfyk1X5DbOlkb2pckDXFSAfjsD5wenb88fNrD6fvS+vu90a/tsPpb9vb0SLg=="
+    },
+    "node_modules/css-font-style-keywords": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/css-font-style-keywords/-/css-font-style-keywords-1.0.1.tgz",
+      "integrity": "sha512-0Fn0aTpcDktnR1RzaBYorIxQily85M2KXRpzmxQPgh8pxUN9Fcn00I8u9I3grNr1QXVgCl9T5Imx0ZwKU973Vg=="
+    },
+    "node_modules/css-font-weight-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-font-weight-keywords/-/css-font-weight-keywords-1.0.0.tgz",
+      "integrity": "sha512-5So8/NH+oDD+EzsnF4iaG4ZFHQ3vaViePkL1ZbZ5iC/KrsCY+WHq/lvOgrtmuOQ9pBBZ1ADGpaf+A4lj1Z9eYA=="
+    },
+    "node_modules/css-global-keywords": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/css-global-keywords/-/css-global-keywords-1.0.1.tgz",
+      "integrity": "sha512-X1xgQhkZ9n94WDwntqst5D/FKkmiU0GlJSFZSV3kLvyJ1WC5VeyoXDOuleUD+SIuH9C7W05is++0Woh0CGfKjQ=="
     },
     "node_modules/css-has-pseudo": {
       "version": "0.10.0",
@@ -7053,6 +7444,11 @@
       "integrity": "sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w==",
       "dev": true
     },
+    "node_modules/css-system-font-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-system-font-keywords/-/css-system-font-keywords-1.0.0.tgz",
+      "integrity": "sha512-1umTtVd/fXS25ftfjB71eASCrYhilmEsvDEI6wG/QplnmlfmVM5HkZ/ZX46DT5K3eblFPgLUHt5BRCb0YXkSFA=="
+    },
     "node_modules/css-tree": {
       "version": "1.0.0-alpha.37",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.37.tgz",
@@ -7111,6 +7507,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/csscolorparser": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/csscolorparser/-/csscolorparser-1.0.3.tgz",
+      "integrity": "sha512-umPSgYwZkdFoUrH5hIq5kf0wPSXiro51nPw0j2K/c83KflkPSTBGMz6NJvMB+07VlL0y7VPo6QJcDjcgKTTm3w=="
     },
     "node_modules/cssdb": {
       "version": "4.4.0",
@@ -7463,11 +7864,126 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
       "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
-      "dev": true,
       "dependencies": {
         "es5-ext": "^0.10.50",
         "type": "^1.0.1"
       }
+    },
+    "node_modules/d3-array": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
+    },
+    "node_modules/d3-collection": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-collection/-/d3-collection-1.0.7.tgz",
+      "integrity": "sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A=="
+    },
+    "node_modules/d3-color": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
+      "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q=="
+    },
+    "node_modules/d3-dispatch": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-1.0.6.tgz",
+      "integrity": "sha512-fVjoElzjhCEy+Hbn8KygnmMS7Or0a9sI2UzGwoB7cCtvI1XpVN9GpoYlnb3xt2YV66oXYb1fLJ8GMvP4hdU1RA=="
+    },
+    "node_modules/d3-force": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-1.2.1.tgz",
+      "integrity": "sha512-HHvehyaiUlVo5CxBJ0yF/xny4xoaxFxDnBXNvNcfW9adORGZfyNF1dj6DGLKyk4Yh3brP/1h3rnDzdIAwL08zg==",
+      "dependencies": {
+        "d3-collection": "1",
+        "d3-dispatch": "1",
+        "d3-quadtree": "1",
+        "d3-timer": "1"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
+      "integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ=="
+    },
+    "node_modules/d3-geo": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.12.1.tgz",
+      "integrity": "sha512-XG4d1c/UJSEX9NfU02KwBL6BYPj8YKHxgBEw5om2ZnTRSbIcego6dhHwcxuSR3clxh0EpE38os1DVPOmnYtTPg==",
+      "dependencies": {
+        "d3-array": "1"
+      }
+    },
+    "node_modules/d3-geo-projection": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/d3-geo-projection/-/d3-geo-projection-2.9.0.tgz",
+      "integrity": "sha512-ZULvK/zBn87of5rWAfFMc9mJOipeSo57O+BBitsKIXmU4rTVAnX1kSsJkE0R+TxY8pGNoM1nbyRRE7GYHhdOEQ==",
+      "dependencies": {
+        "commander": "2",
+        "d3-array": "1",
+        "d3-geo": "^1.12.0",
+        "resolve": "^1.1.10"
+      },
+      "bin": {
+        "geo2svg": "bin/geo2svg",
+        "geograticule": "bin/geograticule",
+        "geoproject": "bin/geoproject",
+        "geoquantize": "bin/geoquantize",
+        "geostitch": "bin/geostitch"
+      }
+    },
+    "node_modules/d3-geo-projection/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-1.1.9.tgz",
+      "integrity": "sha512-j8tPxlqh1srJHAtxfvOUwKNYJkQuBFdM1+JAUfq6xqH5eAqf93L7oG1NVqDa4CpFZNvnNKtCYEUC8KY9yEn9lQ=="
+    },
+    "node_modules/d3-interpolate": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+      "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+      "dependencies": {
+        "d3-color": "1"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="
+    },
+    "node_modules/d3-quadtree": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-1.0.7.tgz",
+      "integrity": "sha512-RKPAeXnkC59IDGD0Wu5mANy0Q2V28L+fNe65pOCXVdVuTJS3WPKaJlFHer32Rbh9gIo9qMuJXio8ra4+YmIymA=="
+    },
+    "node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz",
+      "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA=="
+    },
+    "node_modules/d3-time-format": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
+      "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
+      "dependencies": {
+        "d3-time": "1"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.10.tgz",
+      "integrity": "sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw=="
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -7556,8 +8072,7 @@
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
-      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-      "dev": true
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
     },
     "node_modules/deepmerge": {
       "version": "4.2.2",
@@ -7724,6 +8239,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/defined": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.1.tgz",
+      "integrity": "sha512-hsBd2qSVCRE+5PmNdHt1uzyrFu5d3RwmFDKzyNZMFq/EwDNJF7Ee5+D5oEKF0hU6LhtoUF1macFvOe4AskQC1Q==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/del": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/del/-/del-4.1.1.tgz",
@@ -7833,6 +8356,11 @@
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
       "dev": true
+    },
+    "node_modules/detect-kerning": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-kerning/-/detect-kerning-2.1.2.tgz",
+      "integrity": "sha512-I3JIbrnKPAntNLl1I6TpSQQdQ4AutYzv/sKMFKbepawV/hlH0GmYKhUoOEMd4xqaUHT+Bm0f4127lh5qs1m1tw=="
     },
     "node_modules/detect-newline": {
       "version": "3.1.0",
@@ -8119,6 +8647,28 @@
       "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==",
       "dev": true
     },
+    "node_modules/draw-svg-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/draw-svg-path/-/draw-svg-path-1.0.0.tgz",
+      "integrity": "sha512-P8j3IHxcgRMcY6sDzr0QvJDLzBnJJqpTG33UZ2Pvp8rw0apCHhJCWqYprqrXjrgHnJ6tuhP1iTJSAodPDHxwkg==",
+      "dependencies": {
+        "abs-svg-path": "~0.1.1",
+        "normalize-svg-path": "~0.1.0"
+      }
+    },
+    "node_modules/dtype": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dtype/-/dtype-2.0.0.tgz",
+      "integrity": "sha512-s2YVcLKdFGS0hpFqJaTwscsyt0E8nNFdmo73Ocd81xNPj4URI4rj6D60A+vFMIw7BXWlb4yRkEwfBqcZzPGiZg==",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/dup": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/dup/-/dup-1.0.0.tgz",
+      "integrity": "sha512-Bz5jxMMC0wgp23Zm15ip1x8IhYRqJvF3nFC0UInJUDkN1z4uNPk9jTnfCUJXbOGiQ1JbXLQsiV41Fb+HXcj5BA=="
+    },
     "node_modules/duplexer": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
@@ -8129,13 +8679,17 @@
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
       "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
-      "dev": true,
       "dependencies": {
         "end-of-stream": "^1.0.0",
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0",
         "stream-shift": "^1.0.0"
       }
+    },
+    "node_modules/earcut": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
+      "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ=="
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -8158,6 +8712,19 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.71.tgz",
       "integrity": "sha512-Hk61vXXKRb2cd3znPE9F+2pLWdIOmP7GjiTj45y6L3W/lO+hSnUSUhq+6lEaERWBdZOHbk2s3YV5c9xVl3boVw==",
       "dev": true
+    },
+    "node_modules/element-size": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/element-size/-/element-size-1.1.1.tgz",
+      "integrity": "sha512-eaN+GMOq/Q+BIWy0ybsgpcYImjGIdNLyjLFJU4XsLHXYQao5jCNb36GyN6C2qwmDDYSfIBmKpPpr4VnBdLCsPQ=="
+    },
+    "node_modules/elementary-circuits-directed-graph": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/elementary-circuits-directed-graph/-/elementary-circuits-directed-graph-1.3.1.tgz",
+      "integrity": "sha512-ZEiB5qkn2adYmpXGnJKkxT8uJHlW/mxmBpmeqawEHzPxh9HkLD4/1mFYX5l0On+f6rcPIt8/EWlRU2Vo3fX6dQ==",
+      "dependencies": {
+        "strongly-connected-components": "^1.0.1"
+      }
     },
     "node_modules/elliptic": {
       "version": "6.5.4",
@@ -8220,7 +8787,6 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "dev": true,
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -8358,7 +8924,6 @@
       "version": "0.10.53",
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
       "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
-      "dev": true,
       "dependencies": {
         "es6-iterator": "~2.0.3",
         "es6-symbol": "~3.1.3",
@@ -8369,7 +8934,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
-      "dev": true,
       "dependencies": {
         "d": "1",
         "es5-ext": "^0.10.35",
@@ -8380,10 +8944,20 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
       "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
-      "dev": true,
       "dependencies": {
         "d": "^1.0.1",
         "ext": "^1.1.2"
+      }
+    },
+    "node_modules/es6-weak-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
+      "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "^0.10.46",
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.1"
       }
     },
     "node_modules/escalade": {
@@ -9205,7 +9779,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true,
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -9257,7 +9830,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9281,7 +9853,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "dev": true,
       "engines": {
         "node": ">=0.8.x"
       }
@@ -9592,7 +10163,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/ext/-/ext-1.6.0.tgz",
       "integrity": "sha512-sdBImtzkq2HpkdRLtlLWDa6w4DX22ijZLKx8BMPUuKe1c5lbN6xwQDQCxSfxBQnHZ13ls/FH0MQZx/q/gr6FQg==",
-      "dev": true,
       "dependencies": {
         "type": "^2.5.0"
       }
@@ -9600,8 +10170,7 @@
     "node_modules/ext/node_modules/type": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/type/-/type-2.6.0.tgz",
-      "integrity": "sha512-eiDBDOmkih5pMbo9OqsqPRGMljLodLcwd5XD5JbtNB0o89xZAwynY9EdCDsJU7LtcVCClu9DvM7/0Ep1hYX3EQ==",
-      "dev": true
+      "integrity": "sha512-eiDBDOmkih5pMbo9OqsqPRGMljLodLcwd5XD5JbtNB0o89xZAwynY9EdCDsJU7LtcVCClu9DvM7/0Ep1hYX3EQ=="
     },
     "node_modules/extend-shallow": {
       "version": "3.0.2",
@@ -9668,6 +10237,23 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/falafel": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/falafel/-/falafel-2.2.5.tgz",
+      "integrity": "sha512-HuC1qF9iTnHDnML9YZAdCDQwT0yKl/U55K4XSUXqGAA2GLoafFgWRqdAbhWJxXaYD4pyoVxAJ8wH670jMpI9DQ==",
+      "dependencies": {
+        "acorn": "^7.1.1",
+        "isarray": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/falafel/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -9696,6 +10282,14 @@
         "node": ">=8.6.0"
       }
     },
+    "node_modules/fast-isnumeric": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/fast-isnumeric/-/fast-isnumeric-1.1.4.tgz",
+      "integrity": "sha512-1mM8qOr2LYz8zGaUdmiqRDiuue00Dxjgcb1NQR7TnhLVh6sQyngP9xvLo7Sl7LZpP/sk5eb+bcyWXw530NTBZw==",
+      "dependencies": {
+        "is-string-blank": "^1.0.1"
+      }
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -9704,8 +10298,7 @@
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-      "dev": true
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "node_modules/fastq": {
       "version": "1.13.0",
@@ -9906,6 +10499,19 @@
       "deprecated": "flatten is deprecated in favor of utility frameworks such as lodash.",
       "dev": true
     },
+    "node_modules/flatten-vertex-data": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/flatten-vertex-data/-/flatten-vertex-data-1.0.2.tgz",
+      "integrity": "sha512-BvCBFK2NZqerFTdMDgqfHBwxYWnxeCkwONsw6PvBMcUXqo8U/KDWwmXhqx1x2kLIg7DqIsJfOaJFOmlua3Lxuw==",
+      "dependencies": {
+        "dtype": "^2.0.0"
+      }
+    },
+    "node_modules/flip-pixels": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/flip-pixels/-/flip-pixels-1.0.2.tgz",
+      "integrity": "sha512-oXbJGbjDnfJRWPC7Va38EFhd+A8JWE5/hCiKcK8qjCdbLj9DTpsq6MEudwpRTH+V4qq+Jw7d3pUgQdSr3x3mTA=="
+    },
     "node_modules/flush-write-stream": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
@@ -9934,6 +10540,22 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/font-atlas": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/font-atlas/-/font-atlas-2.1.0.tgz",
+      "integrity": "sha512-kP3AmvX+HJpW4w3d+PiPR2X6E1yvsBXt2yhuCw+yReO9F1WYhvZwx3c95DGZGwg9xYzDGrgJYa885xmVA+28Cg==",
+      "dependencies": {
+        "css-font": "^1.0.0"
+      }
+    },
+    "node_modules/font-measure": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/font-measure/-/font-measure-1.2.2.tgz",
+      "integrity": "sha512-mRLEpdrWzKe9hbfaF3Qpr06TAjquuBVP5cHy4b3hyeNdjc9i0PO6HniGsX5vjL5OWv7+Bd++NiooNpT/s8BvIA==",
+      "dependencies": {
+        "css-font": "^1.2.0"
       }
     },
     "node_modules/for-in": {
@@ -10222,7 +10844,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
       "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
-      "dev": true,
       "dependencies": {
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0"
@@ -10290,8 +10911,7 @@
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "node_modules/functional-red-black-tree": {
       "version": "1.0.1",
@@ -10326,6 +10946,11 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/geojson-vt": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-3.2.1.tgz",
+      "integrity": "sha512-EvGQQi/zPrDA6zr6BnJD/YhwAkBP8nnJ9emh3EnHQKVMfg/MRVtPbMYdgVy/IaEmn4UfagD2a6fafPDL5hbtwg=="
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -10334,6 +10959,11 @@
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
+    },
+    "node_modules/get-canvas-context": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-canvas-context/-/get-canvas-context-1.0.2.tgz",
+      "integrity": "sha512-LnpfLf/TNzr9zVOGiIY6aKCz8EKuXmlYNV7CM2pUjBa/B+c2I15tS7KLySep75+FuerJdmArvJLcsAXWEy2H0A=="
     },
     "node_modules/get-intrinsic": {
       "version": "1.1.1",
@@ -10402,6 +11032,54 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/gl-mat4": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gl-mat4/-/gl-mat4-1.2.0.tgz",
+      "integrity": "sha512-sT5C0pwB1/e9G9AvAoLsoaJtbMGjfd/jfxo8jMCKqYYEnjZuFvqV5rehqar0538EmssjdDeiEWnKyBSTw7quoA=="
+    },
+    "node_modules/gl-matrix": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.3.tgz",
+      "integrity": "sha512-wcCp8vu8FT22BnvKVPjXa/ICBWRq/zjFfdofZy1WSpQZpphblv12/bOQLBC1rMM7SGOFS9ltVmKOHil5+Ml7gA=="
+    },
+    "node_modules/gl-text": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/gl-text/-/gl-text-1.3.1.tgz",
+      "integrity": "sha512-/f5gcEMiZd+UTBJLTl3D+CkCB/0UFGTx3nflH8ZmyWcLkZhsZ1+Xx5YYkw2rgWAzgPeE35xCqBuHSoMKQVsR+w==",
+      "dependencies": {
+        "bit-twiddle": "^1.0.2",
+        "color-normalize": "^1.5.0",
+        "css-font": "^1.2.0",
+        "detect-kerning": "^2.1.2",
+        "es6-weak-map": "^2.0.3",
+        "flatten-vertex-data": "^1.0.2",
+        "font-atlas": "^2.1.0",
+        "font-measure": "^1.2.2",
+        "gl-util": "^3.1.2",
+        "is-plain-obj": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "parse-rect": "^1.2.0",
+        "parse-unit": "^1.0.1",
+        "pick-by-alias": "^1.2.0",
+        "regl": "^2.0.0",
+        "to-px": "^1.0.1",
+        "typedarray-pool": "^1.1.0"
+      }
+    },
+    "node_modules/gl-util": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/gl-util/-/gl-util-3.1.3.tgz",
+      "integrity": "sha512-dvRTggw5MSkJnCbh74jZzSoTOGnVYK+Bt+Ckqm39CVcl6+zSsxqWk4lr5NKhkqXHL6qvZAU9h17ZF8mIskY9mA==",
+      "dependencies": {
+        "is-browser": "^2.0.1",
+        "is-firefox": "^1.0.3",
+        "is-plain-obj": "^1.1.0",
+        "number-is-integer": "^1.0.1",
+        "object-assign": "^4.1.0",
+        "pick-by-alias": "^1.2.0",
+        "weak-map": "^1.0.5"
       }
     },
     "node_modules/glob": {
@@ -10503,11 +11181,186 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/glsl-inject-defines": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/glsl-inject-defines/-/glsl-inject-defines-1.0.3.tgz",
+      "integrity": "sha512-W49jIhuDtF6w+7wCMcClk27a2hq8znvHtlGnrYkSWEr8tHe9eA2dcnohlcAmxLYBSpSSdzOkRdyPTrx9fw49+A==",
+      "dependencies": {
+        "glsl-token-inject-block": "^1.0.0",
+        "glsl-token-string": "^1.0.1",
+        "glsl-tokenizer": "^2.0.2"
+      }
+    },
+    "node_modules/glsl-resolve": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/glsl-resolve/-/glsl-resolve-0.0.1.tgz",
+      "integrity": "sha512-xxFNsfnhZTK9NBhzJjSBGX6IOqYpvBHxxmo+4vapiljyGNCY0Bekzn0firQkQrazK59c1hYxMDxYS8MDlhw4gA==",
+      "dependencies": {
+        "resolve": "^0.6.1",
+        "xtend": "^2.1.2"
+      }
+    },
+    "node_modules/glsl-resolve/node_modules/resolve": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.6.3.tgz",
+      "integrity": "sha512-UHBY3viPlJKf85YijDUcikKX6tmF4SokIDp518ZDVT92JNDcG5uKIthaT/owt3Sar0lwtOafsQuwrg22/v2Dwg=="
+    },
+    "node_modules/glsl-resolve/node_modules/xtend": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.2.0.tgz",
+      "integrity": "sha512-SLt5uylT+4aoXxXuwtQp5ZnMMzhDb1Xkg4pEqc00WUJCQifPfV9Ub1VrNhp9kXkrjZD2I2Hl8WnjP37jzZLPZw==",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/glsl-token-assignments": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/glsl-token-assignments/-/glsl-token-assignments-2.0.2.tgz",
+      "integrity": "sha512-OwXrxixCyHzzA0U2g4btSNAyB2Dx8XrztY5aVUCjRSh4/D0WoJn8Qdps7Xub3sz6zE73W3szLrmWtQ7QMpeHEQ=="
+    },
+    "node_modules/glsl-token-defines": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/glsl-token-defines/-/glsl-token-defines-1.0.0.tgz",
+      "integrity": "sha512-Vb5QMVeLjmOwvvOJuPNg3vnRlffscq2/qvIuTpMzuO/7s5kT+63iL6Dfo2FYLWbzuiycWpbC0/KV0biqFwHxaQ==",
+      "dependencies": {
+        "glsl-tokenizer": "^2.0.0"
+      }
+    },
+    "node_modules/glsl-token-depth": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/glsl-token-depth/-/glsl-token-depth-1.1.2.tgz",
+      "integrity": "sha512-eQnIBLc7vFf8axF9aoi/xW37LSWd2hCQr/3sZui8aBJnksq9C7zMeUYHVJWMhFzXrBU7fgIqni4EhXVW4/krpg=="
+    },
+    "node_modules/glsl-token-descope": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/glsl-token-descope/-/glsl-token-descope-1.0.2.tgz",
+      "integrity": "sha512-kS2PTWkvi/YOeicVjXGgX5j7+8N7e56srNDEHDTVZ1dcESmbmpmgrnpjPcjxJjMxh56mSXYoFdZqb90gXkGjQw==",
+      "dependencies": {
+        "glsl-token-assignments": "^2.0.0",
+        "glsl-token-depth": "^1.1.0",
+        "glsl-token-properties": "^1.0.0",
+        "glsl-token-scope": "^1.1.0"
+      }
+    },
+    "node_modules/glsl-token-inject-block": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/glsl-token-inject-block/-/glsl-token-inject-block-1.1.0.tgz",
+      "integrity": "sha512-q/m+ukdUBuHCOtLhSr0uFb/qYQr4/oKrPSdIK2C4TD+qLaJvqM9wfXIF/OOBjuSA3pUoYHurVRNao6LTVVUPWA=="
+    },
+    "node_modules/glsl-token-properties": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/glsl-token-properties/-/glsl-token-properties-1.0.1.tgz",
+      "integrity": "sha512-dSeW1cOIzbuUoYH0y+nxzwK9S9O3wsjttkq5ij9ZGw0OS41BirKJzzH48VLm8qLg+au6b0sINxGC0IrGwtQUcA=="
+    },
+    "node_modules/glsl-token-scope": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/glsl-token-scope/-/glsl-token-scope-1.1.2.tgz",
+      "integrity": "sha512-YKyOMk1B/tz9BwYUdfDoHvMIYTGtVv2vbDSLh94PT4+f87z21FVdou1KNKgF+nECBTo0fJ20dpm0B1vZB1Q03A=="
+    },
+    "node_modules/glsl-token-string": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/glsl-token-string/-/glsl-token-string-1.0.1.tgz",
+      "integrity": "sha512-1mtQ47Uxd47wrovl+T6RshKGkRRCYWhnELmkEcUAPALWGTFe2XZpH3r45XAwL2B6v+l0KNsCnoaZCSnhzKEksg=="
+    },
+    "node_modules/glsl-token-whitespace-trim": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/glsl-token-whitespace-trim/-/glsl-token-whitespace-trim-1.0.0.tgz",
+      "integrity": "sha512-ZJtsPut/aDaUdLUNtmBYhaCmhIjpKNg7IgZSfX5wFReMc2vnj8zok+gB/3Quqs0TsBSX/fGnqUUYZDqyuc2xLQ=="
+    },
+    "node_modules/glsl-tokenizer": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/glsl-tokenizer/-/glsl-tokenizer-2.1.5.tgz",
+      "integrity": "sha512-XSZEJ/i4dmz3Pmbnpsy3cKh7cotvFlBiZnDOwnj/05EwNp2XrhQ4XKJxT7/pDt4kp4YcpRSKz8eTV7S+mwV6MA==",
+      "dependencies": {
+        "through2": "^0.6.3"
+      }
+    },
+    "node_modules/glsl-tokenizer/node_modules/readable-stream": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
+    "node_modules/glsl-tokenizer/node_modules/string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ=="
+    },
+    "node_modules/glsl-tokenizer/node_modules/through2": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+      "integrity": "sha512-RkK/CCESdTKQZHdmKICijdKKsCRVHs5KsLZ6pACAmF/1GPUQhonHSXWNERctxEp7RmvjdNbZTL5z9V7nSCXKcg==",
+      "dependencies": {
+        "readable-stream": ">=1.0.33-1 <1.1.0-0",
+        "xtend": ">=4.0.0 <4.1.0-0"
+      }
+    },
+    "node_modules/glslify": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/glslify/-/glslify-7.1.1.tgz",
+      "integrity": "sha512-bud98CJ6kGZcP9Yxcsi7Iz647wuDz3oN+IZsjCRi5X1PI7t/xPKeL0mOwXJjo+CRZMqvq0CkSJiywCcY7kVYog==",
+      "dependencies": {
+        "bl": "^2.2.1",
+        "concat-stream": "^1.5.2",
+        "duplexify": "^3.4.5",
+        "falafel": "^2.1.0",
+        "from2": "^2.3.0",
+        "glsl-resolve": "0.0.1",
+        "glsl-token-whitespace-trim": "^1.0.0",
+        "glslify-bundle": "^5.0.0",
+        "glslify-deps": "^1.2.5",
+        "minimist": "^1.2.5",
+        "resolve": "^1.1.5",
+        "stack-trace": "0.0.9",
+        "static-eval": "^2.0.5",
+        "through2": "^2.0.1",
+        "xtend": "^4.0.0"
+      },
+      "bin": {
+        "glslify": "bin.js"
+      }
+    },
+    "node_modules/glslify-bundle": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/glslify-bundle/-/glslify-bundle-5.1.1.tgz",
+      "integrity": "sha512-plaAOQPv62M1r3OsWf2UbjN0hUYAB7Aph5bfH58VxJZJhloRNbxOL9tl/7H71K7OLJoSJ2ZqWOKk3ttQ6wy24A==",
+      "dependencies": {
+        "glsl-inject-defines": "^1.0.1",
+        "glsl-token-defines": "^1.0.0",
+        "glsl-token-depth": "^1.1.1",
+        "glsl-token-descope": "^1.0.2",
+        "glsl-token-scope": "^1.1.1",
+        "glsl-token-string": "^1.0.1",
+        "glsl-token-whitespace-trim": "^1.0.0",
+        "glsl-tokenizer": "^2.0.2",
+        "murmurhash-js": "^1.0.0",
+        "shallow-copy": "0.0.1"
+      }
+    },
+    "node_modules/glslify-deps": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/glslify-deps/-/glslify-deps-1.3.2.tgz",
+      "integrity": "sha512-7S7IkHWygJRjcawveXQjRXLO2FTjijPDYC7QfZyAQanY+yGLCFHYnPtsGT9bdyHiwPTw/5a1m1M9hamT2aBpag==",
+      "dependencies": {
+        "@choojs/findup": "^0.2.0",
+        "events": "^3.2.0",
+        "glsl-resolve": "0.0.1",
+        "glsl-tokenizer": "^2.0.0",
+        "graceful-fs": "^4.1.2",
+        "inherits": "^2.0.1",
+        "map-limit": "0.0.1",
+        "resolve": "^1.0.0"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.9",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
-      "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==",
-      "dev": true
+      "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ=="
     },
     "node_modules/graphql": {
       "version": "15.8.0",
@@ -10532,6 +11385,11 @@
       "peerDependencies": {
         "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
       }
+    },
+    "node_modules/grid-index": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/grid-index/-/grid-index-1.1.0.tgz",
+      "integrity": "sha512-HZRwumpOGUrHyxO5bqKZL0B0GlUpwtCAzZ42sgxUPniu33R1LSFH5yrIcBCHjkctCAh3mtWKcKd9J4vDDdeVHA=="
     },
     "node_modules/growly": {
       "version": "1.3.0",
@@ -10569,7 +11427,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1"
       },
@@ -10593,6 +11450,22 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-hover": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-hover/-/has-hover-1.0.1.tgz",
+      "integrity": "sha512-0G6w7LnlcpyDzpeGUTuT0CEw05+QlMuGVk1IHNAlHrGJITGodjZu3x8BNDUMfKJSZXNB2ZAclqc1bvrd+uUpfg==",
+      "dependencies": {
+        "is-browser": "^2.0.1"
+      }
+    },
+    "node_modules/has-passive-events": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-passive-events/-/has-passive-events-1.0.0.tgz",
+      "integrity": "sha512-2vSj6IeIsgvsRMyeQ0JaCX5Q3lX4zMn5HpoVc7MEhQ6pv8Iq9rsXjsp+E5ZwaT7T0xhMT0KmU8gtt1EFVdbJiw==",
+      "dependencies": {
+        "is-browser": "^2.0.1"
       }
     },
     "node_modules/has-symbols": {
@@ -10834,6 +11707,11 @@
       "resolved": "https://registry.npmjs.org/hsla-regex/-/hsla-regex-1.0.0.tgz",
       "integrity": "sha1-wc56MWjIxmFAM6S194d/OyJfnDg=",
       "dev": true
+    },
+    "node_modules/hsluv": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/hsluv/-/hsluv-0.0.3.tgz",
+      "integrity": "sha512-08iL2VyCRbkQKBySkSh6m8zMUa3sADAxGVWs3Z1aPcUkTJeK0ETG4Fc27tEmQBGUAXZjIsXOZqBvacuVNSC/fQ=="
     },
     "node_modules/html-encoding-sniffer": {
       "version": "2.0.1",
@@ -11187,7 +12065,6 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
       },
@@ -11261,7 +12138,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -11290,6 +12166,16 @@
       "dev": true,
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/image-palette": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/image-palette/-/image-palette-2.1.0.tgz",
+      "integrity": "sha512-3ImSEWD26+xuQFdP0RWR4WSXadZwvgrFhjGNpMEapTG1tf2XrBFS2dlKK5hNgH4UIaSQlSUFRn1NeA+zULIWbQ==",
+      "dependencies": {
+        "color-id": "^1.1.0",
+        "pxls": "^2.0.0",
+        "quantize": "^1.0.2"
       }
     },
     "node_modules/immer": {
@@ -11516,8 +12402,7 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/ini": {
       "version": "1.3.8",
@@ -11619,6 +12504,11 @@
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
+    "node_modules/is-base64": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-base64/-/is-base64-0.1.0.tgz",
+      "integrity": "sha512-WRRyllsGXJM7ZN7gPTCCQ/6wNPTRDwiWdPK66l5sJzcU/oOzcIcRRf0Rux8bkpox/1yjt0F6VJRsQOIG2qz5sg=="
+    },
     "node_modules/is-bigint": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
@@ -11644,6 +12534,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-blob": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-blob/-/is-blob-2.1.0.tgz",
+      "integrity": "sha512-SZ/fTft5eUhQM6oF/ZaASFDEdbFVe89Imltn9uZr03wdKMcWNVYSMjQPFtg05QuNkt5l5c135ElvXEQG0rk4tw==",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-boolean-object": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
@@ -11659,6 +12560,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-browser": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-browser/-/is-browser-2.1.0.tgz",
+      "integrity": "sha512-F5rTJxDQ2sW81fcfOR1GnCXT6sVJC104fCyfj+mjpwNEwaPYSn5fte5jiHmBg3DHsIoL/l8Kvw5VN5SsTRcRFQ=="
     },
     "node_modules/is-buffer": {
       "version": "1.1.6",
@@ -11726,7 +12632,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
       "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
-      "dev": true,
       "dependencies": {
         "has": "^1.0.3"
       },
@@ -11820,6 +12725,30 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-finite": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
+      "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-firefox": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-firefox/-/is-firefox-1.0.3.tgz",
+      "integrity": "sha512-6Q9ITjvWIm0Xdqv+5U12wgOKEM2KoBw4Y926m0OFkvlCxnbG94HKAsVz8w3fWcfAS5YA2fJORXX1dLrkprCCxA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-float-array": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-float-array/-/is-float-array-1.0.0.tgz",
+      "integrity": "sha512-4ew1Sx6B6kEAl3T3NOM0yB94J3NZnBdNt4paw0e8nY73yHHTeTEhyQ3Lj7EQEnv5LD+GxNTaT4L46jcKjjpLiQ=="
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -11850,11 +12779,24 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-iexplorer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-iexplorer/-/is-iexplorer-1.0.0.tgz",
+      "integrity": "sha512-YeLzceuwg3K6O0MLM3UyUUjKAlyULetwryFp1mHy1I5PfArK0AEqlfa+MR4gkJjcbuJXoDJCvXbyqZVf5CR2Sg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-in-browser": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/is-in-browser/-/is-in-browser-1.1.3.tgz",
       "integrity": "sha1-Vv9NtoOgeMYILrldrX3GLh0E+DU=",
       "dev": true
+    },
+    "node_modules/is-mobile": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-mobile/-/is-mobile-2.2.2.tgz",
+      "integrity": "sha512-wW/SXnYJkTjs++tVK5b6kVITZpAZPtUrt9SF80vvxGiF/Oywal+COk1jlRkiVq15RFNEQKQY31TkV24/1T5cVg=="
     },
     "node_modules/is-module": {
       "version": "1.0.0",
@@ -11902,7 +12844,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11944,7 +12885,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
       "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12052,6 +12992,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-string-blank": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-string-blank/-/is-string-blank-1.0.1.tgz",
+      "integrity": "sha512-9H+ZBCVs3L9OYqv8nuUAzpcT9OTgMD1yAWrG7ihlnibdkbtB850heAmYWxHuXc4CHy4lKeK69tN+ny1K7gBIrw=="
+    },
+    "node_modules/is-svg-path": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-svg-path/-/is-svg-path-1.0.2.tgz",
+      "integrity": "sha512-Lj4vePmqpPR1ZnRctHv8ltSh1OrSxHkhUkd7wi+VQdcdP15/KvQFyk7LhNuM7ZW0EVbJz8kZLVmL9quLrfq4Kg=="
+    },
     "node_modules/is-symbol": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
@@ -12109,8 +13059,7 @@
     "node_modules/isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-      "peer": true
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -13203,6 +14152,11 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/kdbush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-3.0.0.tgz",
+      "integrity": "sha512-hRkd6/XW4HTsA9vjVpY9tuXJYLSlelnkTmVFu4M9/7MIYQtFcHpbugAU7UbOfjOiVSVYl2fqgBuJ32JUmRo5Ew=="
+    },
     "node_modules/killable": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/killable/-/killable-1.0.1.tgz",
@@ -13367,8 +14321,7 @@
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
     "node_modules/lodash.template": {
       "version": "4.5.0",
@@ -13504,6 +14457,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/map-limit": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/map-limit/-/map-limit-0.0.1.tgz",
+      "integrity": "sha512-pJpcfLPnIF/Sk3taPW21G/RQsEEirGaFpCW3oXRwH9dnFHPHNGjNyvh++rdmC2fNqEaTw2MhYJraoJWAHx8kEg==",
+      "dependencies": {
+        "once": "~1.3.0"
+      }
+    },
+    "node_modules/map-limit/node_modules/once": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+      "integrity": "sha512-6vaNInhu+CHxtONf3zw3vq4SP2DOQhjBvIa3rNcG0+P7eKWlYH6Peu7rHizSloRU2EwMz6GraLieis9Ac9+p1w==",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/map-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
@@ -13512,6 +14481,47 @@
       "dependencies": {
         "object-visit": "^1.0.0"
       },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/mapbox-gl": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.10.1.tgz",
+      "integrity": "sha512-0aHt+lFUpYfvh0kMIqXqNXqoYMuhuAsMlw87TbhWrw78Tx2zfuPI0Lx31/YPUgJ+Ire0tzQ4JnuBL7acDNXmMg==",
+      "dependencies": {
+        "@mapbox/geojson-rewind": "^0.5.0",
+        "@mapbox/geojson-types": "^1.0.2",
+        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
+        "@mapbox/mapbox-gl-supported": "^1.5.0",
+        "@mapbox/point-geometry": "^0.1.0",
+        "@mapbox/tiny-sdf": "^1.1.1",
+        "@mapbox/unitbezier": "^0.0.0",
+        "@mapbox/vector-tile": "^1.3.1",
+        "@mapbox/whoots-js": "^3.1.0",
+        "csscolorparser": "~1.0.3",
+        "earcut": "^2.2.2",
+        "geojson-vt": "^3.2.1",
+        "gl-matrix": "^3.2.1",
+        "grid-index": "^1.1.0",
+        "minimist": "^1.2.5",
+        "murmurhash-js": "^1.0.0",
+        "pbf": "^3.2.1",
+        "potpack": "^1.0.1",
+        "quickselect": "^2.0.0",
+        "rw": "^1.3.3",
+        "supercluster": "^7.0.0",
+        "tinyqueue": "^2.0.3",
+        "vt-pbf": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6.4.0"
+      }
+    },
+    "node_modules/math-log2": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/math-log2/-/math-log2-1.0.1.tgz",
+      "integrity": "sha512-9W0yGtkaMAkf74XGYVy4Dqw3YUMnTNB2eeiw9aQbUl4A3KmuCEHTt2DgAB07ENzOYAjsYSAYufkAq0Zd+jU7zA==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13772,10 +14782,12 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/minipass": {
       "version": "3.1.6",
@@ -13884,6 +14896,34 @@
         "mkdirp": "bin/cmd.js"
       }
     },
+    "node_modules/mouse-change": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/mouse-change/-/mouse-change-1.4.0.tgz",
+      "integrity": "sha512-vpN0s+zLL2ykyyUDh+fayu9Xkor5v/zRD9jhSqjRS1cJTGS0+oakVZzNm5n19JvvEj0you+MXlYTpNxUDQUjkQ==",
+      "dependencies": {
+        "mouse-event": "^1.0.0"
+      }
+    },
+    "node_modules/mouse-event": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/mouse-event/-/mouse-event-1.0.5.tgz",
+      "integrity": "sha512-ItUxtL2IkeSKSp9cyaX2JLUuKk2uMoxBg4bbOWVd29+CskYJR9BGsUqtXenNzKbnDshvupjUewDIYVrOB6NmGw=="
+    },
+    "node_modules/mouse-event-offset": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mouse-event-offset/-/mouse-event-offset-3.0.2.tgz",
+      "integrity": "sha512-s9sqOs5B1Ykox3Xo8b3Ss2IQju4UwlW6LSR+Q5FXWpprJ5fzMLefIIItr3PH8RwzfGy6gxs/4GAmiNuZScE25w=="
+    },
+    "node_modules/mouse-wheel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mouse-wheel/-/mouse-wheel-1.2.0.tgz",
+      "integrity": "sha512-+OfYBiUOCTWcTECES49neZwL5AoGkXE+lFjIvzwNCnYRlso+EnfvovcBxGoyQ0yQt806eSPjS675K0EwWknXmw==",
+      "dependencies": {
+        "right-now": "^1.0.0",
+        "signum": "^1.0.0",
+        "to-px": "^1.0.1"
+      }
+    },
     "node_modules/move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -13913,8 +14953,7 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/multicast-dns": {
       "version": "6.2.3",
@@ -13940,6 +14979,20 @@
       "resolved": "https://registry.npmjs.org/multimap/-/multimap-1.1.0.tgz",
       "integrity": "sha512-0ZIR9PasPxGXmRsEF8jsDzndzHDj7tIav+JUmvIFB/WHswliFnquxECT/De7GR4yg99ky/NlRKJT82G1y271bw==",
       "dev": true
+    },
+    "node_modules/mumath": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/mumath/-/mumath-3.3.4.tgz",
+      "integrity": "sha512-VAFIOG6rsxoc7q/IaY3jdjmrsuX9f15KlRLYTHmixASBZkZEKC1IFqE2BC5CdhXmK6WLM1Re33z//AGmeRI6FA==",
+      "deprecated": "Redundant dependency in your project.",
+      "dependencies": {
+        "almost-equal": "^1.1.0"
+      }
+    },
+    "node_modules/murmurhash-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
+      "integrity": "sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw=="
     },
     "node_modules/nan": {
       "version": "2.15.0",
@@ -13982,6 +15035,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/native-promise-only": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
+      "integrity": "sha512-zkVhZUA3y8mbz652WrL5x0fB0ehrBkulWT3TomAQ9iDtyXZvzKeEA6GPxAItBYeNYl5yngKRX612qHOhvMkDeg=="
+    },
     "node_modules/native-url": {
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/native-url/-/native-url-0.2.6.tgz",
@@ -13996,6 +15054,30 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "node_modules/needle": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.9.1.tgz",
+      "integrity": "sha512-6R9fqJ5Zcmf+uYaFgdIHmLwNldn5HbK8L5ybn7Uz+ylX/rnOsSp1AHcvQSrCaFN+qNM1wpymHqD7mVasEOlHGQ==",
+      "dependencies": {
+        "debug": "^3.2.6",
+        "iconv-lite": "^0.4.4",
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "needle": "bin/needle"
+      },
+      "engines": {
+        "node": ">= 4.4.x"
+      }
+    },
+    "node_modules/needle/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
     },
     "node_modules/negotiator": {
       "version": "0.6.3",
@@ -14015,8 +15097,7 @@
     "node_modules/next-tick": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
-      "dev": true
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
     },
     "node_modules/nice-try": {
       "version": "1.0.5",
@@ -14146,6 +15227,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/normalize-svg-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-svg-path/-/normalize-svg-path-0.1.0.tgz",
+      "integrity": "sha512-1/kmYej2iedi5+ROxkRESL/pI02pkg0OBnaR4hJkSIX6+ORzepwbuUXfrdZaPjysTsJInj0Rj5NuX027+dMBvA=="
+    },
     "node_modules/normalize-url": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
@@ -14190,6 +15276,17 @@
       "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
       "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=",
       "dev": true
+    },
+    "node_modules/number-is-integer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-integer/-/number-is-integer-1.0.1.tgz",
+      "integrity": "sha512-Dq3iuiFBkrbmuQjGFFF3zckXNCQoSD37/SdSbgcBailUx6knDvDwb5CympBgcoWHy36sfS12u74MHYkXyHq6bg==",
+      "dependencies": {
+        "is-finite": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/nwsapi": {
       "version": "2.2.0",
@@ -14319,7 +15416,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -14475,7 +15571,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -14735,6 +15830,11 @@
         "node": ">=6"
       }
     },
+    "node_modules/parenthesis": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/parenthesis/-/parenthesis-3.1.8.tgz",
+      "integrity": "sha512-KF/U8tk54BgQewkJPvB4s/US3VQY68BRDpH638+7O/n58TpnwiwnOtGIOsT2/i+M78s61BBpeC83STB88d8sqw=="
+    },
     "node_modules/parse-asn1": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.6.tgz",
@@ -14765,6 +15865,24 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/parse-rect": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/parse-rect/-/parse-rect-1.2.0.tgz",
+      "integrity": "sha512-4QZ6KYbnE6RTwg9E0HpLchUM9EZt6DnDxajFZZDSV4p/12ZJEvPO702DZpGvRYEPo00yKDys7jASi+/w7aO8LA==",
+      "dependencies": {
+        "pick-by-alias": "^1.2.0"
+      }
+    },
+    "node_modules/parse-svg-path": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/parse-svg-path/-/parse-svg-path-0.1.2.tgz",
+      "integrity": "sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ=="
+    },
+    "node_modules/parse-unit": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-unit/-/parse-unit-1.0.1.tgz",
+      "integrity": "sha512-hrqldJHokR3Qj88EIlV/kAyAi/G5R2+R56TBANxNMy0uPlYcttx0jnMW6Yx5KsKPSbC3KddM/7qQm3+0wEXKxg=="
     },
     "node_modules/parse5": {
       "version": "6.0.1",
@@ -14848,8 +15966,7 @@
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "node_modules/path-to-regexp": {
       "version": "1.8.0",
@@ -14867,6 +15984,18 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pbf": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.2.1.tgz",
+      "integrity": "sha512-ClrV7pNOn7rtmoQVF4TS1vyU0WhYRnP92fzbfF75jAIwpnzdJXf8iTd4CMEqO4yUenH6NDqLiwjqlh6QgZzgLQ==",
+      "dependencies": {
+        "ieee754": "^1.1.12",
+        "resolve-protobuf-schema": "^2.1.0"
+      },
+      "bin": {
+        "pbf": "bin/pbf"
       }
     },
     "node_modules/pbkdf2": {
@@ -14888,8 +16017,12 @@
     "node_modules/performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-      "dev": true
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
+    "node_modules/pick-by-alias": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pick-by-alias/-/pick-by-alias-1.2.0.tgz",
+      "integrity": "sha512-ESj2+eBxhGrcA1azgHs7lARG5+5iLakc/6nlfbpjcLl00HuuUOIuORhYXN4D1HfvMSKuVtFQjAlnwi1JHEeDIw=="
     },
     "node_modules/picocolors": {
       "version": "1.0.0",
@@ -15094,6 +16227,62 @@
         "node": ">=6"
       }
     },
+    "node_modules/plotly.js": {
+      "version": "2.17.1",
+      "resolved": "https://registry.npmjs.org/plotly.js/-/plotly.js-2.17.1.tgz",
+      "integrity": "sha512-Tgjk1FrA4TIJAMEFlJqq9swyRsdwKas90DNHoV6MZ+uxmcEO7O/kdEonu9LEIrmiNiuIQgGxwNERH7jrJxjAlQ==",
+      "dependencies": {
+        "@plotly/d3": "3.8.0",
+        "@plotly/d3-sankey": "0.7.2",
+        "@plotly/d3-sankey-circular": "0.33.1",
+        "@turf/area": "^6.4.0",
+        "@turf/bbox": "^6.4.0",
+        "@turf/centroid": "^6.0.2",
+        "canvas-fit": "^1.5.0",
+        "color-alpha": "1.0.4",
+        "color-normalize": "1.5.0",
+        "color-parse": "1.3.8",
+        "color-rgba": "2.1.1",
+        "country-regex": "^1.1.0",
+        "d3-force": "^1.2.1",
+        "d3-format": "^1.4.5",
+        "d3-geo": "^1.12.1",
+        "d3-geo-projection": "^2.9.0",
+        "d3-hierarchy": "^1.1.9",
+        "d3-interpolate": "^1.4.0",
+        "d3-time": "^1.1.0",
+        "d3-time-format": "^2.2.3",
+        "fast-isnumeric": "^1.1.4",
+        "gl-mat4": "^1.2.0",
+        "gl-text": "^1.3.1",
+        "glslify": "^7.1.1",
+        "has-hover": "^1.0.1",
+        "has-passive-events": "^1.0.0",
+        "is-mobile": "^2.2.2",
+        "mapbox-gl": "1.10.1",
+        "mouse-change": "^1.4.0",
+        "mouse-event-offset": "^3.0.2",
+        "mouse-wheel": "^1.2.0",
+        "native-promise-only": "^0.8.1",
+        "parse-svg-path": "^0.1.2",
+        "point-in-polygon": "^1.1.0",
+        "polybooljs": "^1.2.0",
+        "probe-image-size": "^7.2.3",
+        "regl": "npm:@plotly/regl@^2.1.2",
+        "regl-error2d": "^2.0.12",
+        "regl-line2d": "^3.1.2",
+        "regl-scatter2d": "^3.2.8",
+        "regl-splom": "^1.0.14",
+        "strongly-connected-components": "^1.0.1",
+        "superscript-text": "^1.0.0",
+        "svg-path-sdf": "^1.1.3",
+        "tinycolor2": "^1.4.2",
+        "to-px": "1.0.1",
+        "topojson-client": "^3.1.0",
+        "webgl-context": "^2.2.0",
+        "world-calendars": "^1.0.3"
+      }
+    },
     "node_modules/pluralize": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
@@ -15114,6 +16303,16 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/point-in-polygon": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/point-in-polygon/-/point-in-polygon-1.1.0.tgz",
+      "integrity": "sha512-3ojrFwjnnw8Q9242TzgXuTD+eKiutbzyslcq1ydfu82Db2y+Ogbmyrkpv0Hgj31qwT3lbS9+QAAO/pIQM35XRw=="
+    },
+    "node_modules/polybooljs": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/polybooljs/-/polybooljs-1.2.0.tgz",
+      "integrity": "sha512-mKjR5nolISvF+q2BtC1fi/llpxBPTQ3wLWN8+ldzdw2Hocpc8C72ZqnamCM4Z6z+68GVVjkeM01WJegQmZ8MEQ=="
     },
     "node_modules/popper.js": {
       "version": "1.16.1-lts",
@@ -18592,6 +19791,11 @@
         "node": ">=6.14.4"
       }
     },
+    "node_modules/potpack": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.2.tgz",
+      "integrity": "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ=="
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -18671,6 +19875,16 @@
         "node": ">= 10"
       }
     },
+    "node_modules/probe-image-size": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/probe-image-size/-/probe-image-size-7.2.3.tgz",
+      "integrity": "sha512-HubhG4Rb2UH8YtV4ba0Vp5bQ7L78RTONYu/ujmCu5nBI8wGv24s4E9xSKBi0N1MowRpxk76pFCpJtW0KPzOK0w==",
+      "dependencies": {
+        "lodash.merge": "^4.6.2",
+        "needle": "^2.5.2",
+        "stream-parser": "~0.3.1"
+      }
+    },
     "node_modules/process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -18683,8 +19897,7 @@
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "node_modules/progress": {
       "version": "2.0.3",
@@ -18746,6 +19959,11 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/protocol-buffers-schema": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
+      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw=="
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -18832,6 +20050,41 @@
         "node": ">=6"
       }
     },
+    "node_modules/pxls": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/pxls/-/pxls-2.3.2.tgz",
+      "integrity": "sha512-pQkwgbLqWPcuES5iEmGa10OlCf5xG0blkIF3dg7PpRZShbTYcvAdfFfGL03SMrkaSUaa/V0UpN9HWg40O2AIIw==",
+      "dependencies": {
+        "arr-flatten": "^1.1.0",
+        "compute-dims": "^1.1.0",
+        "flip-pixels": "^1.0.2",
+        "is-browser": "^2.1.0",
+        "is-buffer": "^2.0.3",
+        "to-uint8": "^1.4.1"
+      }
+    },
+    "node_modules/pxls/node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/q": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
@@ -18852,6 +20105,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/quantize": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/quantize/-/quantize-1.0.2.tgz",
+      "integrity": "sha512-25P7wI2UoDbIQsQp50ARkt+5pwPsOq7G/BqvT5xAbapnRoNWMN8/p55H9TXd5MuENiJnm5XICB2H2aDZGwts7w==",
+      "engines": {
+        "node": ">=0.10.21"
       }
     },
     "node_modules/query-string": {
@@ -18912,11 +20173,15 @@
         }
       ]
     },
+    "node_modules/quickselect": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
+      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="
+    },
     "node_modules/raf": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
       "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
-      "dev": true,
       "dependencies": {
         "performance-now": "^2.1.0"
       }
@@ -19305,6 +20570,18 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+    },
+    "node_modules/react-plotly.js": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/react-plotly.js/-/react-plotly.js-2.6.0.tgz",
+      "integrity": "sha512-g93xcyhAVCSt9kV1svqG1clAEdL6k3U+jjuSzfTV7owaSU9Go6Ph8bl25J+jKfKvIGAEYpe4qj++WHJuc9IaeA==",
+      "dependencies": {
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "plotly.js": ">1.34.0",
+        "react": ">0.13.0"
+      }
     },
     "node_modules/react-redux": {
       "version": "7.2.6",
@@ -19782,7 +21059,6 @@
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
       "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-      "dev": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -19796,14 +21072,12 @@
     "node_modules/readable-stream/node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "node_modules/readable-stream/node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -19926,6 +21200,11 @@
       "integrity": "sha512-jbD/FT0+9MBU2XAZluI7w2OBs1RBi6p9M83nkoZayQXXU9e8Robt69FcZc7wU4eJD/YFTjn1JdCk3rbMJajz8Q==",
       "dev": true
     },
+    "node_modules/regex-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/regex-regex/-/regex-regex-1.0.0.tgz",
+      "integrity": "sha512-FPbEhFTLpxKNgHKay3zMfkHzFK2ebViAlyvsz5euO4kwekH0T6fAL4Sdo2CgQ7Y1tGB5HqQm8SBq7pW5GegvVA=="
+    },
     "node_modules/regexp-tree": {
       "version": "0.1.24",
       "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.24.tgz",
@@ -20005,6 +21284,83 @@
       "dev": true,
       "bin": {
         "jsesc": "bin/jsesc"
+      }
+    },
+    "node_modules/regl": {
+      "name": "@plotly/regl",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@plotly/regl/-/regl-2.1.2.tgz",
+      "integrity": "sha512-Mdk+vUACbQvjd0m/1JJjOOafmkp/EpmHjISsopEz5Av44CBq7rPC05HHNbYGKVyNUF2zmEoBS/TT0pd0SPFFyw=="
+    },
+    "node_modules/regl-error2d": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/regl-error2d/-/regl-error2d-2.0.12.tgz",
+      "integrity": "sha512-r7BUprZoPO9AbyqM5qlJesrSRkl+hZnVKWKsVp7YhOl/3RIpi4UDGASGJY0puQ96u5fBYw/OlqV24IGcgJ0McA==",
+      "dependencies": {
+        "array-bounds": "^1.0.1",
+        "color-normalize": "^1.5.0",
+        "flatten-vertex-data": "^1.0.2",
+        "object-assign": "^4.1.1",
+        "pick-by-alias": "^1.2.0",
+        "to-float32": "^1.1.0",
+        "update-diff": "^1.1.0"
+      }
+    },
+    "node_modules/regl-line2d": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/regl-line2d/-/regl-line2d-3.1.2.tgz",
+      "integrity": "sha512-nmT7WWS/WxmXAQMkgaMKWXaVmwJ65KCrjbqHGOUjjqQi6shfT96YbBOvelXwO9hG7/hjvbzjtQ2UO0L3e7YaXQ==",
+      "dependencies": {
+        "array-bounds": "^1.0.1",
+        "array-find-index": "^1.0.2",
+        "array-normalize": "^1.1.4",
+        "color-normalize": "^1.5.0",
+        "earcut": "^2.1.5",
+        "es6-weak-map": "^2.0.3",
+        "flatten-vertex-data": "^1.0.2",
+        "glslify": "^7.0.0",
+        "object-assign": "^4.1.1",
+        "parse-rect": "^1.2.0",
+        "pick-by-alias": "^1.2.0",
+        "to-float32": "^1.1.0"
+      }
+    },
+    "node_modules/regl-scatter2d": {
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/regl-scatter2d/-/regl-scatter2d-3.2.8.tgz",
+      "integrity": "sha512-bqrqJyeHkGBa9mEfuBnRd7FUtdtZ1l+gsM2C5Ugr1U3vJG5K3mdWdVWtOAllZ5FHHyWJV/vgjVvftgFUg6CDig==",
+      "dependencies": {
+        "@plotly/point-cluster": "^3.1.9",
+        "array-range": "^1.0.1",
+        "array-rearrange": "^2.2.2",
+        "clamp": "^1.0.1",
+        "color-id": "^1.1.0",
+        "color-normalize": "^1.5.0",
+        "color-rgba": "^2.1.1",
+        "flatten-vertex-data": "^1.0.2",
+        "glslify": "^7.0.0",
+        "image-palette": "^2.1.0",
+        "is-iexplorer": "^1.0.0",
+        "object-assign": "^4.1.1",
+        "parse-rect": "^1.2.0",
+        "pick-by-alias": "^1.2.0",
+        "to-float32": "^1.1.0",
+        "update-diff": "^1.1.0"
+      }
+    },
+    "node_modules/regl-splom": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/regl-splom/-/regl-splom-1.0.14.tgz",
+      "integrity": "sha512-OiLqjmPRYbd7kDlHC6/zDf6L8lxgDC65BhC8JirhP4ykrK4x22ZyS+BnY8EUinXKDeMgmpRwCvUmk7BK4Nweuw==",
+      "dependencies": {
+        "array-bounds": "^1.0.1",
+        "array-range": "^1.0.1",
+        "color-alpha": "^1.0.4",
+        "flatten-vertex-data": "^1.0.2",
+        "parse-rect": "^1.2.0",
+        "pick-by-alias": "^1.2.0",
+        "raf": "^3.4.1",
+        "regl-scatter2d": "^3.2.3"
       }
     },
     "node_modules/relateurl": {
@@ -20114,7 +21470,6 @@
       "version": "1.22.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
       "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
-      "dev": true,
       "dependencies": {
         "is-core-module": "^2.8.1",
         "path-parse": "^1.0.7",
@@ -20153,6 +21508,14 @@
       "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
       "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==",
       "peer": true
+    },
+    "node_modules/resolve-protobuf-schema": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
+      "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
+      "dependencies": {
+        "protocol-buffers-schema": "^3.3.1"
+      }
     },
     "node_modules/resolve-url": {
       "version": "0.2.1",
@@ -20406,6 +21769,11 @@
       "resolved": "https://registry.npmjs.org/rgba-regex/-/rgba-regex-1.0.0.tgz",
       "integrity": "sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=",
       "dev": true
+    },
+    "node_modules/right-now": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/right-now/-/right-now-1.0.0.tgz",
+      "integrity": "sha512-DA8+YS+sMIVpbsuKgy+Z67L9Lxb1p05mNxRpDPNksPDEFir4vmBlUtuN9jkTGn9YMMdlBuK7XQgFiz6ws+yhSg=="
     },
     "node_modules/rimraf": {
       "version": "3.0.2",
@@ -21274,11 +22642,15 @@
         "aproba": "^1.1.1"
       }
     },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="
+    },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/safe-identifier": {
       "version": "0.4.2",
@@ -21298,8 +22670,7 @@
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/sane": {
       "version": "4.1.0",
@@ -21659,8 +23030,7 @@
     "node_modules/sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-      "dev": true
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "node_modules/saxes": {
       "version": "5.0.1",
@@ -21928,6 +23298,11 @@
         "sha.js": "bin.js"
       }
     },
+    "node_modules/shallow-copy": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz",
+      "integrity": "sha512-b6i4ZpVuUxB9h5gfCxPiusKYkqTMOjEbBs4wMaFbkfia4yFv92UKZ6Df8WXcKbn08JNL/abvg3FnMAOfakDvUw=="
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -21981,6 +23356,11 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
+    },
+    "node_modules/signum": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/signum/-/signum-1.0.0.tgz",
+      "integrity": "sha512-yodFGwcyt59XRh7w5W3jPcIQb3Bwi21suEfT7MAWnBX3iCdklJpgDgvGT9o04UonglZN5SNMfJFkHIR/jO8GHw=="
     },
     "node_modules/simple-swizzle": {
       "version": "0.2.2",
@@ -22445,6 +23825,14 @@
       "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
       "dev": true
     },
+    "node_modules/stack-trace": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
+      "integrity": "sha512-vjUc6sfgtgY0dxCdnc40mK6Oftjo9+2K8H/NG81TMhgL392FtiPA9tn9RLyTxXmTLPJPjF3VyzFp6bsWFLisMQ==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/stack-utils": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.5.tgz",
@@ -22471,6 +23859,99 @@
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.2.1.tgz",
       "integrity": "sha512-h88QkzREN/hy8eRdyNhhsO7RSJ5oyTqxxmmn0dzBIMUclZsjpfmrsg81vp8mjjAs2vAZ72nyWxRUwSwmh0e4xg==",
       "dev": true
+    },
+    "node_modules/static-eval": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.1.0.tgz",
+      "integrity": "sha512-agtxZ/kWSsCkI5E4QifRwsaPs0P0JmZV6dkLz6ILYfFYQGn+5plctanRN+IC8dJRiFkyXHrwEE3W9Wmx67uDbw==",
+      "dependencies": {
+        "escodegen": "^1.11.1"
+      }
+    },
+    "node_modules/static-eval/node_modules/escodegen": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
+      "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=4.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/static-eval/node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/static-eval/node_modules/levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
+      "dependencies": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/static-eval/node_modules/optionator": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+      "dependencies": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.6",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "word-wrap": "~1.2.3"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/static-eval/node_modules/prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/static-eval/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/static-eval/node_modules/type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
+      "dependencies": {
+        "prelude-ls": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/static-extend": {
       "version": "0.1.2",
@@ -22610,11 +24091,31 @@
         "xtend": "^4.0.0"
       }
     },
+    "node_modules/stream-parser": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/stream-parser/-/stream-parser-0.3.1.tgz",
+      "integrity": "sha512-bJ/HgKq41nlKvlhccD5kaCr/P+Hu0wPNKPJOH7en+YrJu/9EgqUF+88w5Jb6KNcjOFMhfX4B2asfeAtIGuHObQ==",
+      "dependencies": {
+        "debug": "2"
+      }
+    },
+    "node_modules/stream-parser/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/stream-parser/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+    },
     "node_modules/stream-shift": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
-      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
-      "dev": true
+      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
     },
     "node_modules/strict-uri-encode": {
       "version": "1.1.0",
@@ -22678,6 +24179,23 @@
       "resolved": "https://registry.npmjs.org/string-natural-compare/-/string-natural-compare-3.0.1.tgz",
       "integrity": "sha512-n3sPwynL1nwKi3WJ6AIsClwBMa0zTi54fn2oLU6ndfTSIO05xaznjSf15PcBZU6FNWbmN5Q6cxT4V5hGvB4taw==",
       "dev": true
+    },
+    "node_modules/string-split-by": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/string-split-by/-/string-split-by-1.0.0.tgz",
+      "integrity": "sha512-KaJKY+hfpzNyet/emP81PJA9hTVSfxNLS9SFTWxdCnnW1/zOOwiV248+EfoX7IQFcBaOp4G5YE6xTJMF+pLg6A==",
+      "dependencies": {
+        "parenthesis": "^3.1.5"
+      }
+    },
+    "node_modules/string-to-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-to-arraybuffer/-/string-to-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-DaGZidzi93dwjQen5I2osxR9ERS/R7B1PFyufNMnzhj+fmlDQAc1DSDIJVJhgI8Oq221efIMbABUBdPHDRt43Q==",
+      "dependencies": {
+        "atob-lite": "^2.0.0",
+        "is-base64": "^0.1.0"
+      }
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -22834,6 +24352,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strongly-connected-components": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strongly-connected-components/-/strongly-connected-components-1.0.1.tgz",
+      "integrity": "sha512-i0TFx4wPcO0FwX+4RkLJi1MxmcTv90jNZgxMu9XRnMXMeFUY1VJlIoXpZunPUvUUqbCT1pg5PEkFqqpcaElNaA=="
+    },
     "node_modules/style-inject": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/style-inject/-/style-inject-0.3.0.tgz",
@@ -22951,6 +24474,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/supercluster": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-7.1.5.tgz",
+      "integrity": "sha512-EulshI3pGUM66o6ZdH3ReiFcvHpM3vAigyK+vcxdjpJyEbIIrtbmBdY23mGgnI24uXiGFvrGq9Gkum/8U7vJWg==",
+      "dependencies": {
+        "kdbush": "^3.0.0"
+      }
+    },
+    "node_modules/superscript-text": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/superscript-text/-/superscript-text-1.0.0.tgz",
+      "integrity": "sha512-gwu8l5MtRZ6koO0icVTlmN5pm7Dhh1+Xpe9O4x6ObMAsW+3jPbW14d1DsBq1F4wiI+WOFjXF35pslgec/G8yCQ=="
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -22980,7 +24516,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -22988,11 +24523,47 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svg-arc-to-cubic-bezier": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/svg-arc-to-cubic-bezier/-/svg-arc-to-cubic-bezier-3.2.0.tgz",
+      "integrity": "sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g=="
+    },
     "node_modules/svg-parser": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/svg-parser/-/svg-parser-2.0.4.tgz",
       "integrity": "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==",
       "dev": true
+    },
+    "node_modules/svg-path-bounds": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/svg-path-bounds/-/svg-path-bounds-1.0.2.tgz",
+      "integrity": "sha512-H4/uAgLWrppIC0kHsb2/dWUYSmb4GE5UqH06uqWBcg6LBjX2fu0A8+JrO2/FJPZiSsNOKZAhyFFgsLTdYUvSqQ==",
+      "dependencies": {
+        "abs-svg-path": "^0.1.1",
+        "is-svg-path": "^1.0.1",
+        "normalize-svg-path": "^1.0.0",
+        "parse-svg-path": "^0.1.2"
+      }
+    },
+    "node_modules/svg-path-bounds/node_modules/normalize-svg-path": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-svg-path/-/normalize-svg-path-1.1.0.tgz",
+      "integrity": "sha512-r9KHKG2UUeB5LoTouwDzBy2VxXlHsiM6fyLQvnJa0S5hrhzqElH/CH7TUGhT1fVvIYBIKf3OpY4YJ4CK+iaqHg==",
+      "dependencies": {
+        "svg-arc-to-cubic-bezier": "^3.0.0"
+      }
+    },
+    "node_modules/svg-path-sdf": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/svg-path-sdf/-/svg-path-sdf-1.1.3.tgz",
+      "integrity": "sha512-vJJjVq/R5lSr2KLfVXVAStktfcfa1pNFjFOgyJnzZFXlO/fDZ5DmM8FpnSKKzLPfEYTVeXuVBTHF296TpxuJVg==",
+      "dependencies": {
+        "bitmap-sdf": "^1.0.0",
+        "draw-svg-path": "^1.0.0",
+        "is-svg-path": "^1.0.1",
+        "parse-svg-path": "^0.1.2",
+        "svg-path-bounds": "^1.0.1"
+      }
     },
     "node_modules/svgo": {
       "version": "1.3.2",
@@ -23622,7 +25193,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
       "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-      "dev": true,
       "dependencies": {
         "readable-stream": "~2.3.6",
         "xtend": "~4.0.1"
@@ -23663,11 +25233,31 @@
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
     },
+    "node_modules/tinycolor2": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.5.2.tgz",
+      "integrity": "sha512-h80m9GPFGbcLzZByXlNSEhp1gf8Dy+VX/2JCGUZsWLo7lV1mnE/XlxGYgRBoMLJh1lIDXP0EMC4RPTjlRaV+Bg=="
+    },
+    "node_modules/tinyqueue": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
+      "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA=="
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
       "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "dev": true
+    },
+    "node_modules/to-array-buffer": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/to-array-buffer/-/to-array-buffer-3.2.0.tgz",
+      "integrity": "sha512-zN33mwi0gpL+7xW1ITLfJ48CEj6ZQW0ZAP0MU+2W3kEY0PAIncyuxmD4OqkUVhPAbTP7amq9j/iwvZKYS+lzSQ==",
+      "dependencies": {
+        "flatten-vertex-data": "^1.0.2",
+        "is-blob": "^2.0.1",
+        "string-to-arraybuffer": "^1.0.0"
+      }
     },
     "node_modules/to-arraybuffer": {
       "version": "1.0.1",
@@ -23683,6 +25273,11 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/to-float32": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/to-float32/-/to-float32-1.1.0.tgz",
+      "integrity": "sha512-keDnAusn/vc+R3iEiSDw8TOF7gPiTLdK1ArvWtYbJQiVfmRg6i/CAvbKq3uIS0vWroAC7ZecN3DjQKw3aSklUg=="
     },
     "node_modules/to-object-path": {
       "version": "0.3.0",
@@ -23706,6 +25301,14 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/to-px": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/to-px/-/to-px-1.0.1.tgz",
+      "integrity": "sha512-2y3LjBeIZYL19e5gczp14/uRWFDtDUErJPVN3VU9a7SJO+RjGRtYR47aMN2bZgGlxvW4ZcEz2ddUPVHXcMfuXw==",
+      "dependencies": {
+        "parse-unit": "^1.0.1"
       }
     },
     "node_modules/to-regex": {
@@ -23744,6 +25347,18 @@
         "ret": "~0.1.10"
       }
     },
+    "node_modules/to-uint8": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/to-uint8/-/to-uint8-1.4.1.tgz",
+      "integrity": "sha512-o+ochsMlTZyucbww8It401FC2Rx+OP2RpDeYbA6h+y9HgedDl1UjdsJ9CmzKEG7AFP9es5PmJ4eDWeeeXihESg==",
+      "dependencies": {
+        "arr-flatten": "^1.1.0",
+        "clamp": "^1.0.1",
+        "is-base64": "^0.1.0",
+        "is-float-array": "^1.0.0",
+        "to-array-buffer": "^3.0.0"
+      }
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -23752,6 +25367,24 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/topojson-client": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.1.0.tgz",
+      "integrity": "sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==",
+      "dependencies": {
+        "commander": "2"
+      },
+      "bin": {
+        "topo2geo": "bin/topo2geo",
+        "topomerge": "bin/topomerge",
+        "topoquantize": "bin/topoquantize"
+      }
+    },
+    "node_modules/topojson-client/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "node_modules/tough-cookie": {
       "version": "4.0.0",
@@ -23889,8 +25522,7 @@
     "node_modules/type": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
-      "dev": true
+      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -23938,11 +25570,24 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/type-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/type-name/-/type-name-2.0.2.tgz",
+      "integrity": "sha512-kkgkuqR/jKdKO5oh/I2SMu2dGbLXoJq0zkdgbxaqYK+hr9S9edwVVGf+tMUFTx2gH9TN2+Zu9JZ/Njonb3cjhA=="
+    },
     "node_modules/typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-      "dev": true
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    },
+    "node_modules/typedarray-pool": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/typedarray-pool/-/typedarray-pool-1.2.0.tgz",
+      "integrity": "sha512-YTSQbzX43yvtpfRtIDAYygoYtgT+Rpjuxy9iOpczrjpXLgGoyG7aS5USJXV2d3nn8uHTeb9rXDvzS27zUg5KYQ==",
+      "dependencies": {
+        "bit-twiddle": "^1.0.0",
+        "dup": "^1.0.0"
+      }
     },
     "node_modules/typedarray-to-buffer": {
       "version": "3.1.5",
@@ -24108,8 +25753,7 @@
     "node_modules/unquote": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
-      "integrity": "sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ=",
-      "dev": true
+      "integrity": "sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ="
     },
     "node_modules/unset-value": {
       "version": "1.0.0",
@@ -24174,6 +25818,11 @@
         "node": ">=4",
         "yarn": "*"
       }
+    },
+    "node_modules/update-diff": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/update-diff/-/update-diff-1.1.0.tgz",
+      "integrity": "sha512-rCiBPiHxZwT4+sBhEbChzpO5hYHjm91kScWgdHf4Qeafs6Ba7MBl+d9GlGv72bcTZQO0sLmtQS1pHSWoCLtN/A=="
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
@@ -24283,8 +25932,7 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "node_modules/util.promisify": {
       "version": "1.0.0",
@@ -24308,6 +25956,40 @@
       "integrity": "sha1-ihagXURWV6Oupe7MWxKk+lN5dyw=",
       "dev": true
     },
+    "node_modules/utils-copy": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/utils-copy/-/utils-copy-1.1.1.tgz",
+      "integrity": "sha512-+NhJVV+PcxjdpkMrVTqXhQHPldlFGca5XR9YnGyNn7kQ0fMi+DqNLzdnhJ4TJ1HNy/HzB7c+FPg3y+4icY99ZA==",
+      "dependencies": {
+        "const-pinf-float64": "^1.0.0",
+        "object-keys": "^1.0.9",
+        "type-name": "^2.0.0",
+        "utils-copy-error": "^1.0.0",
+        "utils-indexof": "^1.0.0",
+        "utils-regex-from-string": "^1.0.0",
+        "validate.io-array": "^1.0.3",
+        "validate.io-buffer": "^1.0.1",
+        "validate.io-nonnegative-integer": "^1.0.0"
+      }
+    },
+    "node_modules/utils-copy-error": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-copy-error/-/utils-copy-error-1.0.1.tgz",
+      "integrity": "sha512-RbJcGPZ6Ru2HQk9SWkvbdWNPX58pt4MO5uXsOQRu4LEGWB3LglkRrmnE/Ph1qWg6ywQ0qj95wTz1OeqQ2l8DCA==",
+      "dependencies": {
+        "object-keys": "^1.0.9",
+        "utils-copy": "^1.1.0"
+      }
+    },
+    "node_modules/utils-indexof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/utils-indexof/-/utils-indexof-1.0.0.tgz",
+      "integrity": "sha512-76QBfRJpn4A0P5uTO1x00x+Yog36w2Pab0n+aT9UfUvVa4l+e8k3p7YwNpDvfQ6+aKGZdxZpxcNotNS4YjFcyg==",
+      "dependencies": {
+        "validate.io-array-like": "^1.0.1",
+        "validate.io-integer-primitive": "^1.0.0"
+      }
+    },
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -24315,6 +25997,15 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/utils-regex-from-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/utils-regex-from-string/-/utils-regex-from-string-1.0.0.tgz",
+      "integrity": "sha512-xKfdmEF19iUu9TKxFiohQUlQTuqYdV80/CxHiudVI37iEV/OA4HHlXZoc4qvuO1B74EcBVpErBreRO/dpdLeYA==",
+      "dependencies": {
+        "regex-regex": "^1.0.0",
+        "validate.io-string-primitive": "^1.0.0"
       }
     },
     "node_modules/uuid": {
@@ -24365,6 +26056,82 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
+    "node_modules/validate.io-array": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/validate.io-array/-/validate.io-array-1.0.6.tgz",
+      "integrity": "sha512-DeOy7CnPEziggrOO5CZhVKJw6S3Yi7e9e65R1Nl/RTN1vTQKnzjfvks0/8kQ40FP/dsjRAOd4hxmJ7uLa6vxkg=="
+    },
+    "node_modules/validate.io-array-like": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/validate.io-array-like/-/validate.io-array-like-1.0.2.tgz",
+      "integrity": "sha512-rGLiN0cvY9OWzQcWP+RtqZR/MK9RUz3gKDTCcRLtEQ/BvlanMF5PyqtVIN+CgrIBCv/ypfme9v7r4yMJPYpbNA==",
+      "dependencies": {
+        "const-max-uint32": "^1.0.2",
+        "validate.io-integer-primitive": "^1.0.0"
+      }
+    },
+    "node_modules/validate.io-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/validate.io-buffer/-/validate.io-buffer-1.0.2.tgz",
+      "integrity": "sha512-6Tad+/QYOxWEXsesKYak1mHOzGdPYS4QeHFImWn7ECi4GR0x3vh7+6+1yoLKNXiklKuTFOxHLG3kZy9tPX0GvQ=="
+    },
+    "node_modules/validate.io-integer": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/validate.io-integer/-/validate.io-integer-1.0.5.tgz",
+      "integrity": "sha512-22izsYSLojN/P6bppBqhgUDjCkr5RY2jd+N2a3DCAUey8ydvrZ/OkGvFPR7qfOpwR2LC5p4Ngzxz36g5Vgr/hQ==",
+      "dependencies": {
+        "validate.io-number": "^1.0.3"
+      }
+    },
+    "node_modules/validate.io-integer-primitive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/validate.io-integer-primitive/-/validate.io-integer-primitive-1.0.0.tgz",
+      "integrity": "sha512-4ARGKA4FImVWJgrgttLYsYJmDGwxlhLfDCdq09gyVgohLKKRUfD3VAo1L2vTRCLt6hDhDtFKdZiuYUTWyBggwg==",
+      "dependencies": {
+        "validate.io-number-primitive": "^1.0.0"
+      }
+    },
+    "node_modules/validate.io-matrix-like": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/validate.io-matrix-like/-/validate.io-matrix-like-1.0.2.tgz",
+      "integrity": "sha512-86mqLUIkZCRAOVKZvpCB7sDCw1dKBjBkY+C6WO/wLo/jQx0sOqQZz3LLtDw0DCfuAKxRuhSmIpX3nzr0nWrbdw=="
+    },
+    "node_modules/validate.io-ndarray-like": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/validate.io-ndarray-like/-/validate.io-ndarray-like-1.0.0.tgz",
+      "integrity": "sha512-OV85AosxraPFSXJwzv/d7Cu5/dLiyLtsHmxtHTJcHW1N0uscd0eJ2df1Zk+HdID0eUctUllW/1YuQPUJFv1pTA=="
+    },
+    "node_modules/validate.io-nonnegative-integer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/validate.io-nonnegative-integer/-/validate.io-nonnegative-integer-1.0.0.tgz",
+      "integrity": "sha512-uOMekPwcl84yg8NR7zgIZCZ9pHCtd9CK1Ri51N+ZJLTe1HyLbmdFdy7ZmfkiHkMvB1pOxeQmd1/LBjKhUD1L3A==",
+      "dependencies": {
+        "validate.io-integer": "^1.0.5"
+      }
+    },
+    "node_modules/validate.io-number": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/validate.io-number/-/validate.io-number-1.0.3.tgz",
+      "integrity": "sha512-kRAyotcbNaSYoDnXvb4MHg/0a1egJdLwS6oJ38TJY7aw9n93Fl/3blIXdyYvPOp55CNxywooG/3BcrwNrBpcSg=="
+    },
+    "node_modules/validate.io-number-primitive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/validate.io-number-primitive/-/validate.io-number-primitive-1.0.0.tgz",
+      "integrity": "sha512-8rlCe7N0TRTd50dwk4WNoMXNbX/4+RdtqE3TO6Bk0GJvAgbQlfL5DGr/Pl9ZLbWR6CutMjE2cu+yOoCnFWk+Qw=="
+    },
+    "node_modules/validate.io-positive-integer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/validate.io-positive-integer/-/validate.io-positive-integer-1.0.0.tgz",
+      "integrity": "sha512-eg4LSdyqjICNUZWRilcQ5l+YayRlu6yi+GQsWw1bCmtG9yayOPmLa1fPymEHPPhbvWPAv3w0LLbCsf03pBHZkg==",
+      "dependencies": {
+        "validate.io-integer": "^1.0.5"
+      }
+    },
+    "node_modules/validate.io-string-primitive": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/validate.io-string-primitive/-/validate.io-string-primitive-1.0.1.tgz",
+      "integrity": "sha512-TORbkLMdOFkEbPtfdx76FSVQGSAzyUEMxI+pBq5pfFm1ZzIesP+XiGc6eIK75aKu7RA7a8EcqUv5OrY5wfog5w=="
+    },
     "node_modules/value-equal": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
@@ -24395,6 +26162,16 @@
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
       "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
       "dev": true
+    },
+    "node_modules/vt-pbf": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/vt-pbf/-/vt-pbf-3.1.3.tgz",
+      "integrity": "sha512-2LzDFzt0mZKZ9IpVF2r69G9bXaP2Q2sArJCmcCgvfTdCCZzSyz4aCLoQyUilu37Ll56tCblIZrXFIjNUpGIlmA==",
+      "dependencies": {
+        "@mapbox/point-geometry": "0.1.0",
+        "@mapbox/vector-tile": "^1.3.1",
+        "pbf": "^3.2.1"
+      }
     },
     "node_modules/w3c-hr-time": {
       "version": "1.0.2",
@@ -24725,6 +26502,19 @@
       "dev": true,
       "dependencies": {
         "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "node_modules/weak-map": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/weak-map/-/weak-map-1.0.8.tgz",
+      "integrity": "sha512-lNR9aAefbGPpHO7AEnY0hCFjz1eTkWCXYvkTRrTHs9qv8zJp+SkVYpzfLIFXQQiG3tVvbNFQgVg2bQS8YGgxyw=="
+    },
+    "node_modules/webgl-context": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/webgl-context/-/webgl-context-2.2.0.tgz",
+      "integrity": "sha512-q/fGIivtqTT7PEoF07axFIlHNk/XCPaYpq64btnepopSWvKNFkoORlQYgqDigBIuGA1ExnFd/GnSUnBNEPQY7Q==",
+      "dependencies": {
+        "get-canvas-context": "^1.0.1"
       }
     },
     "node_modules/webidl-conversions": {
@@ -25994,7 +27784,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -26370,6 +28159,14 @@
         "microevent.ts": "~0.1.1"
       }
     },
+    "node_modules/world-calendars": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/world-calendars/-/world-calendars-1.0.3.tgz",
+      "integrity": "sha512-sAjLZkBnsbHkHWVhrsCU5Sa/EVuf9QqgvrN8zyJ2L/F9FR9Oc6CvVK0674+PGAtmmmYQMH98tCUSO4QLQv3/TQ==",
+      "dependencies": {
+        "object-assign": "^4.1.0"
+      }
+    },
     "node_modules/wrap-ansi": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
@@ -26387,8 +28184,7 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "node_modules/write-file-atomic": {
       "version": "3.0.3",
@@ -26451,7 +28247,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.4"
       }
@@ -28038,6 +29833,21 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "@choojs/findup": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@choojs/findup/-/findup-0.2.1.tgz",
+      "integrity": "sha512-YstAqNb0MCN8PjdLCDfRsBcGVRN41f3vgLvaI0IrIcBp4AqILRSS0DeWNGkicC+f/zRIPJLc+9RURVSepwvfBw==",
+      "requires": {
+        "commander": "^2.15.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+        }
+      }
+    },
     "@cnakazawa/watch": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.4.tgz",
@@ -28552,6 +30362,66 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "@mapbox/geojson-rewind": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-rewind/-/geojson-rewind-0.5.2.tgz",
+      "integrity": "sha512-tJaT+RbYGJYStt7wI3cq4Nl4SXxG8W7JDG5DMJu97V25RnbNg3QtQtf+KD+VLjNpWKYsRvXDNmNrBgEETr1ifA==",
+      "requires": {
+        "get-stream": "^6.0.1",
+        "minimist": "^1.2.6"
+      },
+      "dependencies": {
+        "get-stream": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+          "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="
+        }
+      }
+    },
+    "@mapbox/geojson-types": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-types/-/geojson-types-1.0.2.tgz",
+      "integrity": "sha512-e9EBqHHv3EORHrSfbR9DqecPNn+AmuAoQxV6aL8Xu30bJMJR1o8PZLZzpk1Wq7/NfCbuhmakHTPYRhoqLsXRnw=="
+    },
+    "@mapbox/jsonlint-lines-primitives": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
+      "integrity": "sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ=="
+    },
+    "@mapbox/mapbox-gl-supported": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-1.5.0.tgz",
+      "integrity": "sha512-/PT1P6DNf7vjEEiPkVIRJkvibbqWtqnyGaBz3nfRdcxclNSnSdaLU5tfAgcD7I8Yt5i+L19s406YLl1koLnLbg==",
+      "requires": {}
+    },
+    "@mapbox/point-geometry": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
+      "integrity": "sha512-6j56HdLTwWGO0fJPlrZtdU/B13q8Uwmo18Ck2GnGgN9PCFyKTZ3UbXeEdRFh18i9XQ92eH2VdtpJHpBD3aripQ=="
+    },
+    "@mapbox/tiny-sdf": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-1.2.5.tgz",
+      "integrity": "sha512-cD8A/zJlm6fdJOk6DqPUV8mcpyJkRz2x2R+/fYcWDYG3oWbG7/L7Yl/WqQ1VZCjnL9OTIMAn6c+BC5Eru4sQEw=="
+    },
+    "@mapbox/unitbezier": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.0.tgz",
+      "integrity": "sha512-HPnRdYO0WjFjRTSwO3frz1wKaU649OBFPX3Zo/2WZvuRi6zMiRGui8SnPQiQABgqCf8YikDe5t3HViTVw1WUzA=="
+    },
+    "@mapbox/vector-tile": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-1.3.1.tgz",
+      "integrity": "sha512-MCEddb8u44/xfQ3oD+Srl/tNcQoqTw3goGk2oLsrFxOTc3dUp+kAnby3PvAeeBYSMSjSPD1nd1AJA6W49WnoUw==",
+      "requires": {
+        "@mapbox/point-geometry": "~0.1.0"
+      }
+    },
+    "@mapbox/whoots-js": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz",
+      "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q=="
+    },
     "@material-ui/core": {
       "version": "4.12.3",
       "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.12.3.tgz",
@@ -28678,6 +30548,49 @@
           "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
           "dev": true
         }
+      }
+    },
+    "@plotly/d3": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@plotly/d3/-/d3-3.8.0.tgz",
+      "integrity": "sha512-L10iHgzvw3uSic/nQpYehlNzxUQvImwms5U7S95pJAEhrllzkrdQNy1Mc5DW9ab881Yr4fh300gJztKXWZDfkQ=="
+    },
+    "@plotly/d3-sankey": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@plotly/d3-sankey/-/d3-sankey-0.7.2.tgz",
+      "integrity": "sha512-2jdVos1N3mMp3QW0k2q1ph7Gd6j5PY1YihBrwpkFnKqO+cqtZq3AdEYUeSGXMeLsBDQYiqTVcihYfk8vr5tqhw==",
+      "requires": {
+        "d3-array": "1",
+        "d3-collection": "1",
+        "d3-shape": "^1.2.0"
+      }
+    },
+    "@plotly/d3-sankey-circular": {
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@plotly/d3-sankey-circular/-/d3-sankey-circular-0.33.1.tgz",
+      "integrity": "sha512-FgBV1HEvCr3DV7RHhDsPXyryknucxtfnLwPtCKKxdolKyTFYoLX/ibEfX39iFYIL7DYbVeRtP43dbFcrHNE+KQ==",
+      "requires": {
+        "d3-array": "^1.2.1",
+        "d3-collection": "^1.0.4",
+        "d3-shape": "^1.2.0",
+        "elementary-circuits-directed-graph": "^1.0.4"
+      }
+    },
+    "@plotly/point-cluster": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@plotly/point-cluster/-/point-cluster-3.1.9.tgz",
+      "integrity": "sha512-MwaI6g9scKf68Orpr1pHZ597pYx9uP8UEFXLPbsCmuw3a84obwz6pnMXGc90VhgDNeNiLEdlmuK7CPo+5PIxXw==",
+      "requires": {
+        "array-bounds": "^1.0.1",
+        "binary-search-bounds": "^2.0.4",
+        "clamp": "^1.0.1",
+        "defined": "^1.0.0",
+        "dtype": "^2.0.0",
+        "flatten-vertex-data": "^1.0.2",
+        "is-obj": "^1.0.1",
+        "math-log2": "^1.0.1",
+        "parse-rect": "^1.2.0",
+        "pick-by-alias": "^1.2.0"
       }
     },
     "@rollup/plugin-commonjs": {
@@ -29014,6 +30927,46 @@
       "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
       "integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==",
       "dev": true
+    },
+    "@turf/area": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/area/-/area-6.5.0.tgz",
+      "integrity": "sha512-xCZdiuojokLbQ+29qR6qoMD89hv+JAgWjLrwSEWL+3JV8IXKeNFl6XkEJz9HGkVpnXvQKJoRz4/liT+8ZZ5Jyg==",
+      "requires": {
+        "@turf/helpers": "^6.5.0",
+        "@turf/meta": "^6.5.0"
+      }
+    },
+    "@turf/bbox": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-6.5.0.tgz",
+      "integrity": "sha512-RBbLaao5hXTYyyg577iuMtDB8ehxMlUqHEJiMs8jT1GHkFhr6sYre3lmLsPeYEi/ZKj5TP5tt7fkzNdJ4GIVyw==",
+      "requires": {
+        "@turf/helpers": "^6.5.0",
+        "@turf/meta": "^6.5.0"
+      }
+    },
+    "@turf/centroid": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-6.5.0.tgz",
+      "integrity": "sha512-MwE1oq5E3isewPprEClbfU5pXljIK/GUOMbn22UM3IFPDJX0KeoyLNwghszkdmFp/qMGL/M13MMWvU+GNLXP/A==",
+      "requires": {
+        "@turf/helpers": "^6.5.0",
+        "@turf/meta": "^6.5.0"
+      }
+    },
+    "@turf/helpers": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.5.0.tgz",
+      "integrity": "sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw=="
+    },
+    "@turf/meta": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.5.0.tgz",
+      "integrity": "sha512-RrArvtsV0vdsCBegoBtOalgdSOfkBrTJ07VkpiCnq/491W67hnMWmDu7e6Ztw0C3WldRYTXkg3SumfdzZxLBHA==",
+      "requires": {
+        "@turf/helpers": "^6.5.0"
+      }
     },
     "@types/aria-query": {
       "version": "4.2.2",
@@ -29748,6 +31701,11 @@
       "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
       "dev": true
     },
+    "abs-svg-path": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/abs-svg-path/-/abs-svg-path-0.1.1.tgz",
+      "integrity": "sha512-d8XPSGjfyzlXC3Xx891DJRyZfqk5JU0BJrDQcsWomFIV1/BIzPW5HDH5iDdWpqWaav0YVIEzT1RHTwWr0FFshA=="
+    },
     "accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -29761,8 +31719,7 @@
     "acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
-      "dev": true
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
     },
     "acorn-globals": {
       "version": "6.0.0",
@@ -29847,6 +31804,11 @@
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
       "dev": true,
       "requires": {}
+    },
+    "almost-equal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/almost-equal/-/almost-equal-1.1.0.tgz",
+      "integrity": "sha512-0V/PkoculFl5+0Lp47JoxUcO0xSxhIBvm+BxHdD/OgXNmdRpRHCFnKVuUoWyS9EzQP+otSGv0m9Lb4yVkQBn2A=="
     },
     "alphanum-sort": {
       "version": "1.0.2",
@@ -30026,14 +31988,23 @@
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
-      "dev": true
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
     },
     "arr-union": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
       "dev": true
+    },
+    "array-bounds": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/array-bounds/-/array-bounds-1.0.1.tgz",
+      "integrity": "sha512-8wdW3ZGk6UjMPJx/glyEt0sLzzwAE1bhToPsO1W2pbpR2gULyxe3BjSiuJFheP50T/GgODVPz2fuMUmIywt8cQ=="
+    },
+    "array-find-index": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+      "integrity": "sha512-M1HQyIXcBGtVywBt8WVdim+lrNaK7VHp99Qt5pSNziXznKHViIBbXWtfRTpEFpF/c4FdfxNAsCCwPp5phBYJtw=="
     },
     "array-flatten": {
       "version": "2.1.2",
@@ -30053,6 +32024,24 @@
         "get-intrinsic": "^1.1.1",
         "is-string": "^1.0.7"
       }
+    },
+    "array-normalize": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/array-normalize/-/array-normalize-1.1.4.tgz",
+      "integrity": "sha512-fCp0wKFLjvSPmCn4F5Tiw4M3lpMZoHlCjfcs7nNzuj3vqQQ1/a8cgB9DXcpDSn18c+coLnaW7rqfcYCvKbyJXg==",
+      "requires": {
+        "array-bounds": "^1.0.0"
+      }
+    },
+    "array-range": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/array-range/-/array-range-1.0.1.tgz",
+      "integrity": "sha512-shdaI1zT3CVNL2hnx9c0JMc0ZogGaxDs5e85akgHWKYa0yVbIyp06Ind3dVkTj/uuFrzaHBOyqFzo+VV6aXgtA=="
+    },
+    "array-rearrange": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/array-rearrange/-/array-rearrange-2.2.2.tgz",
+      "integrity": "sha512-UfobP5N12Qm4Qu4fwLDIi2v6+wZsSf6snYSxAMeKhrh37YGnNWZPRmVEKc/2wfms53TLQnzfpG8wCx2Y/6NG1w=="
     },
     "array-union": {
       "version": "2.1.0",
@@ -30209,6 +32198,11 @@
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
+    },
+    "atob-lite": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-2.0.0.tgz",
+      "integrity": "sha512-LEeSAWeh2Gfa2FtlQE1shxQ8zi5F9GHarrGKz08TMdODD5T4eH6BMsvtnhbWZ+XQn+Gb6om/917ucvRu7l7ukw=="
     },
     "autoprefixer": {
       "version": "9.8.8",
@@ -30614,6 +32608,11 @@
       "dev": true,
       "optional": true
     },
+    "binary-search-bounds": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-2.0.5.tgz",
+      "integrity": "sha512-H0ea4Fd3lS1+sTEB2TgcLoK21lLhwEJzlQv3IN47pJS976Gx4zoWe0ak3q+uYh60ppQxg9F16Ri4tS1sfD4+jA=="
+    },
     "bindings": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
@@ -30622,6 +32621,25 @@
       "optional": true,
       "requires": {
         "file-uri-to-path": "1.0.0"
+      }
+    },
+    "bit-twiddle": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bit-twiddle/-/bit-twiddle-1.0.2.tgz",
+      "integrity": "sha512-B9UhK0DKFZhoTFcfvAzhqsjStvGJp9vYWf3+6SNTtdSQnvIgfkHbgHrg/e4+TH71N2GDu8tpmCVoyfrL1d7ntA=="
+    },
+    "bitmap-sdf": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/bitmap-sdf/-/bitmap-sdf-1.0.4.tgz",
+      "integrity": "sha512-1G3U4n5JE6RAiALMxu0p1XmeZkTeCwGKykzsLTCqVzfSDaN6S7fKnkIkfejogz+iwqBWc0UYAIKnKHNN7pSfDg=="
+    },
+    "bl": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
+      "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
+      "requires": {
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
       }
     },
     "bluebird": {
@@ -30864,8 +32882,7 @@
     "buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
     "buffer-indexof": {
       "version": "1.1.1",
@@ -31024,6 +33041,14 @@
       "integrity": "sha512-Wiz1Psk2MEK0pX3rUzWaunLTZzqS2JYZFzNKqAiJGiuxIjRPLgV6+VDPOg6lQOUxmDwhTlh198JsTTi8Hzw6aQ==",
       "dev": true
     },
+    "canvas-fit": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/canvas-fit/-/canvas-fit-1.5.0.tgz",
+      "integrity": "sha512-onIcjRpz69/Hx5bB5HGbYKUF2uC6QT6Gp+pfpGm3A7mPfcluSLV5v4Zu+oflDUwLdUw0rLIBhUbi0v8hM4FJQQ==",
+      "requires": {
+        "element-size": "^1.1.1"
+      }
+    },
     "capture-exit": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-2.0.0.tgz",
@@ -31117,6 +33142,11 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-0.6.0.tgz",
       "integrity": "sha512-uc2Vix1frTfnuzxxu1Hp4ktSvM3QaI4oXl4ZUqL1wjTu/BGki9TrCWoqLTg/drR1KwAEarXuRFCG2Svr1GxPFw==",
       "dev": true
+    },
+    "clamp": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/clamp/-/clamp-1.0.1.tgz",
+      "integrity": "sha512-kgMuFyE78OC6Dyu3Dy7vcx4uy97EIbVxJB/B0eJ3bUNAkwdNcxYzgKltnyADiYwsR7SEqkkUPsEUT//OVS6XMA=="
     },
     "class-utils": {
       "version": "0.3.6",
@@ -31379,6 +33409,14 @@
         }
       }
     },
+    "color-alpha": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/color-alpha/-/color-alpha-1.0.4.tgz",
+      "integrity": "sha512-lr8/t5NPozTSqli+duAN+x+no/2WaKTeWvxhHGN+aXT6AJ8vPlzLa7UriyjWak0pSC2jHol9JgjBYnnHsGha9A==",
+      "requires": {
+        "color-parse": "^1.3.8"
+      }
+    },
     "color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -31388,11 +33426,57 @@
         "color-name": "~1.1.4"
       }
     },
+    "color-id": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/color-id/-/color-id-1.1.0.tgz",
+      "integrity": "sha512-2iRtAn6dC/6/G7bBIo0uupVrIne1NsQJvJxZOBCzQOfk7jRq97feaDZ3RdzuHakRXXnHGNwglto3pqtRx1sX0g==",
+      "requires": {
+        "clamp": "^1.0.1"
+      }
+    },
     "color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "color-normalize": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/color-normalize/-/color-normalize-1.5.0.tgz",
+      "integrity": "sha512-rUT/HDXMr6RFffrR53oX3HGWkDOP9goSAQGBkUaAYKjOE2JxozccdGyufageWDlInRAjm/jYPrf/Y38oa+7obw==",
+      "requires": {
+        "clamp": "^1.0.1",
+        "color-rgba": "^2.1.1",
+        "dtype": "^2.0.0"
+      }
+    },
+    "color-parse": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-1.3.8.tgz",
+      "integrity": "sha512-1Y79qFv0n1xair3lNMTNeoFvmc3nirMVBij24zbs1f13+7fPpQClMg5b4AuKXLt3szj7BRlHMCXHplkce6XlmA==",
+      "requires": {
+        "color-name": "^1.0.0",
+        "defined": "^1.0.0",
+        "is-plain-obj": "^1.1.0"
+      }
+    },
+    "color-rgba": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/color-rgba/-/color-rgba-2.1.1.tgz",
+      "integrity": "sha512-VaX97wsqrMwLSOR6H7rU1Doa2zyVdmShabKrPEIFywLlHoibgD3QW9Dw6fSqM4+H/LfjprDNAUUW31qEQcGzNw==",
+      "requires": {
+        "clamp": "^1.0.1",
+        "color-parse": "^1.3.8",
+        "color-space": "^1.14.6"
+      }
+    },
+    "color-space": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/color-space/-/color-space-1.16.0.tgz",
+      "integrity": "sha512-A6WMiFzunQ8KEPFmj02OnnoUnqhmSaHaZ/0LVFcPTdlvm8+3aMJ5x1HRHy3bDHPkovkf4sS0f4wsVvwk71fKkg==",
+      "requires": {
+        "hsluv": "^0.0.3",
+        "mumath": "^3.3.4"
+      }
     },
     "color-string": {
       "version": "1.9.0",
@@ -31493,6 +33577,18 @@
         }
       }
     },
+    "compute-dims": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/compute-dims/-/compute-dims-1.1.0.tgz",
+      "integrity": "sha512-YHMiIKjH/8Eom8zATk3g8/lH3HxGCZcVQyEfEoVrfWI7od/WRpTgRGShnei3jArYSx77mQqPxZNokjGHCdLfxg==",
+      "requires": {
+        "utils-copy": "^1.0.0",
+        "validate.io-array": "^1.0.6",
+        "validate.io-matrix-like": "^1.0.2",
+        "validate.io-ndarray-like": "^1.0.0",
+        "validate.io-positive-integer": "^1.0.0"
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -31503,7 +33599,6 @@
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-      "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
         "inherits": "^2.0.3",
@@ -31545,6 +33640,16 @@
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
       "integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==",
       "dev": true
+    },
+    "const-max-uint32": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/const-max-uint32/-/const-max-uint32-1.0.2.tgz",
+      "integrity": "sha512-T8/9bffg5RThuejasJWrwqxs3Q0fsJvyl7/33IB6svroD8JC93E7X60AuuOnDE8RlP6Jlb5FxmlrVDpl9KiU2Q=="
+    },
+    "const-pinf-float64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/const-pinf-float64/-/const-pinf-float64-1.0.0.tgz",
+      "integrity": "sha512-wfs+V4HdSN7C3CWJWR7hVa24yTPn3mDJthwhRIObZBh6UjTjkUMUrCP3UrNGozB/HjTpcScnGXtQUNa+yjsIJQ=="
     },
     "constants-browserify": {
       "version": "1.0.0",
@@ -31660,8 +33765,7 @@
     "core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "dev": true
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "cosmiconfig": {
       "version": "7.0.1",
@@ -31675,6 +33779,11 @@
         "path-type": "^4.0.0",
         "yaml": "^1.10.0"
       }
+    },
+    "country-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/country-regex/-/country-regex-1.1.0.tgz",
+      "integrity": "sha512-iSPlClZP8vX7MC3/u6s3lrDuoQyhQukh5LyABJ3hvfzbQ3Yyayd4fp04zjLnfi267B/B2FkumcWWgrbban7sSA=="
     },
     "create-ecdh": {
       "version": "4.0.4",
@@ -31850,6 +33959,47 @@
         }
       }
     },
+    "css-font": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/css-font/-/css-font-1.2.0.tgz",
+      "integrity": "sha512-V4U4Wps4dPDACJ4WpgofJ2RT5Yqwe1lEH6wlOOaIxMi0gTjdIijsc5FmxQlZ7ZZyKQkkutqqvULOp07l9c7ssA==",
+      "requires": {
+        "css-font-size-keywords": "^1.0.0",
+        "css-font-stretch-keywords": "^1.0.1",
+        "css-font-style-keywords": "^1.0.1",
+        "css-font-weight-keywords": "^1.0.0",
+        "css-global-keywords": "^1.0.1",
+        "css-system-font-keywords": "^1.0.0",
+        "pick-by-alias": "^1.2.0",
+        "string-split-by": "^1.0.0",
+        "unquote": "^1.1.0"
+      }
+    },
+    "css-font-size-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-font-size-keywords/-/css-font-size-keywords-1.0.0.tgz",
+      "integrity": "sha512-Q+svMDbMlelgCfH/RVDKtTDaf5021O486ZThQPIpahnIjUkMUslC+WuOQSWTgGSrNCH08Y7tYNEmmy0hkfMI8Q=="
+    },
+    "css-font-stretch-keywords": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/css-font-stretch-keywords/-/css-font-stretch-keywords-1.0.1.tgz",
+      "integrity": "sha512-KmugPO2BNqoyp9zmBIUGwt58UQSfyk1X5DbOlkb2pckDXFSAfjsD5wenb88fNrD6fvS+vu90a/tsPpb9vb0SLg=="
+    },
+    "css-font-style-keywords": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/css-font-style-keywords/-/css-font-style-keywords-1.0.1.tgz",
+      "integrity": "sha512-0Fn0aTpcDktnR1RzaBYorIxQily85M2KXRpzmxQPgh8pxUN9Fcn00I8u9I3grNr1QXVgCl9T5Imx0ZwKU973Vg=="
+    },
+    "css-font-weight-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-font-weight-keywords/-/css-font-weight-keywords-1.0.0.tgz",
+      "integrity": "sha512-5So8/NH+oDD+EzsnF4iaG4ZFHQ3vaViePkL1ZbZ5iC/KrsCY+WHq/lvOgrtmuOQ9pBBZ1ADGpaf+A4lj1Z9eYA=="
+    },
+    "css-global-keywords": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/css-global-keywords/-/css-global-keywords-1.0.1.tgz",
+      "integrity": "sha512-X1xgQhkZ9n94WDwntqst5D/FKkmiU0GlJSFZSV3kLvyJ1WC5VeyoXDOuleUD+SIuH9C7W05is++0Woh0CGfKjQ=="
+    },
     "css-has-pseudo": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/css-has-pseudo/-/css-has-pseudo-0.10.0.tgz",
@@ -31997,6 +34147,11 @@
       "integrity": "sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w==",
       "dev": true
     },
+    "css-system-font-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-system-font-keywords/-/css-system-font-keywords-1.0.0.tgz",
+      "integrity": "sha512-1umTtVd/fXS25ftfjB71eASCrYhilmEsvDEI6wG/QplnmlfmVM5HkZ/ZX46DT5K3eblFPgLUHt5BRCb0YXkSFA=="
+    },
     "css-tree": {
       "version": "1.0.0-alpha.37",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.37.tgz",
@@ -32036,6 +34191,11 @@
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
       "integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=",
       "dev": true
+    },
+    "csscolorparser": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/csscolorparser/-/csscolorparser-1.0.3.tgz",
+      "integrity": "sha512-umPSgYwZkdFoUrH5hIq5kf0wPSXiro51nPw0j2K/c83KflkPSTBGMz6NJvMB+07VlL0y7VPo6QJcDjcgKTTm3w=="
     },
     "cssdb": {
       "version": "4.4.0",
@@ -32315,11 +34475,121 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
       "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
-      "dev": true,
       "requires": {
         "es5-ext": "^0.10.50",
         "type": "^1.0.1"
       }
+    },
+    "d3-array": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
+    },
+    "d3-collection": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-collection/-/d3-collection-1.0.7.tgz",
+      "integrity": "sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A=="
+    },
+    "d3-color": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
+      "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q=="
+    },
+    "d3-dispatch": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-1.0.6.tgz",
+      "integrity": "sha512-fVjoElzjhCEy+Hbn8KygnmMS7Or0a9sI2UzGwoB7cCtvI1XpVN9GpoYlnb3xt2YV66oXYb1fLJ8GMvP4hdU1RA=="
+    },
+    "d3-force": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-1.2.1.tgz",
+      "integrity": "sha512-HHvehyaiUlVo5CxBJ0yF/xny4xoaxFxDnBXNvNcfW9adORGZfyNF1dj6DGLKyk4Yh3brP/1h3rnDzdIAwL08zg==",
+      "requires": {
+        "d3-collection": "1",
+        "d3-dispatch": "1",
+        "d3-quadtree": "1",
+        "d3-timer": "1"
+      }
+    },
+    "d3-format": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
+      "integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ=="
+    },
+    "d3-geo": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.12.1.tgz",
+      "integrity": "sha512-XG4d1c/UJSEX9NfU02KwBL6BYPj8YKHxgBEw5om2ZnTRSbIcego6dhHwcxuSR3clxh0EpE38os1DVPOmnYtTPg==",
+      "requires": {
+        "d3-array": "1"
+      }
+    },
+    "d3-geo-projection": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/d3-geo-projection/-/d3-geo-projection-2.9.0.tgz",
+      "integrity": "sha512-ZULvK/zBn87of5rWAfFMc9mJOipeSo57O+BBitsKIXmU4rTVAnX1kSsJkE0R+TxY8pGNoM1nbyRRE7GYHhdOEQ==",
+      "requires": {
+        "commander": "2",
+        "d3-array": "1",
+        "d3-geo": "^1.12.0",
+        "resolve": "^1.1.10"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+        }
+      }
+    },
+    "d3-hierarchy": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-1.1.9.tgz",
+      "integrity": "sha512-j8tPxlqh1srJHAtxfvOUwKNYJkQuBFdM1+JAUfq6xqH5eAqf93L7oG1NVqDa4CpFZNvnNKtCYEUC8KY9yEn9lQ=="
+    },
+    "d3-interpolate": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+      "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+      "requires": {
+        "d3-color": "1"
+      }
+    },
+    "d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="
+    },
+    "d3-quadtree": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-1.0.7.tgz",
+      "integrity": "sha512-RKPAeXnkC59IDGD0Wu5mANy0Q2V28L+fNe65pOCXVdVuTJS3WPKaJlFHer32Rbh9gIo9qMuJXio8ra4+YmIymA=="
+    },
+    "d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "requires": {
+        "d3-path": "1"
+      }
+    },
+    "d3-time": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz",
+      "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA=="
+    },
+    "d3-time-format": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
+      "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
+      "requires": {
+        "d3-time": "1"
+      }
+    },
+    "d3-timer": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.10.tgz",
+      "integrity": "sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw=="
     },
     "damerau-levenshtein": {
       "version": "1.0.8",
@@ -32388,8 +34658,7 @@
     "deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
-      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-      "dev": true
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
     },
     "deepmerge": {
       "version": "4.2.2",
@@ -32516,6 +34785,11 @@
         "isobject": "^3.0.1"
       }
     },
+    "defined": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.1.tgz",
+      "integrity": "sha512-hsBd2qSVCRE+5PmNdHt1uzyrFu5d3RwmFDKzyNZMFq/EwDNJF7Ee5+D5oEKF0hU6LhtoUF1macFvOe4AskQC1Q=="
+    },
     "del": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/del/-/del-4.1.1.tgz",
@@ -32605,6 +34879,11 @@
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
       "dev": true
+    },
+    "detect-kerning": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-kerning/-/detect-kerning-2.1.2.tgz",
+      "integrity": "sha512-I3JIbrnKPAntNLl1I6TpSQQdQ4AutYzv/sKMFKbepawV/hlH0GmYKhUoOEMd4xqaUHT+Bm0f4127lh5qs1m1tw=="
     },
     "detect-newline": {
       "version": "3.1.0",
@@ -32845,6 +35124,25 @@
       "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==",
       "dev": true
     },
+    "draw-svg-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/draw-svg-path/-/draw-svg-path-1.0.0.tgz",
+      "integrity": "sha512-P8j3IHxcgRMcY6sDzr0QvJDLzBnJJqpTG33UZ2Pvp8rw0apCHhJCWqYprqrXjrgHnJ6tuhP1iTJSAodPDHxwkg==",
+      "requires": {
+        "abs-svg-path": "~0.1.1",
+        "normalize-svg-path": "~0.1.0"
+      }
+    },
+    "dtype": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dtype/-/dtype-2.0.0.tgz",
+      "integrity": "sha512-s2YVcLKdFGS0hpFqJaTwscsyt0E8nNFdmo73Ocd81xNPj4URI4rj6D60A+vFMIw7BXWlb4yRkEwfBqcZzPGiZg=="
+    },
+    "dup": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/dup/-/dup-1.0.0.tgz",
+      "integrity": "sha512-Bz5jxMMC0wgp23Zm15ip1x8IhYRqJvF3nFC0UInJUDkN1z4uNPk9jTnfCUJXbOGiQ1JbXLQsiV41Fb+HXcj5BA=="
+    },
     "duplexer": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
@@ -32855,13 +35153,17 @@
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
       "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
-      "dev": true,
       "requires": {
         "end-of-stream": "^1.0.0",
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0",
         "stream-shift": "^1.0.0"
       }
+    },
+    "earcut": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
+      "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ=="
     },
     "ee-first": {
       "version": "1.1.1",
@@ -32880,6 +35182,19 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.71.tgz",
       "integrity": "sha512-Hk61vXXKRb2cd3znPE9F+2pLWdIOmP7GjiTj45y6L3W/lO+hSnUSUhq+6lEaERWBdZOHbk2s3YV5c9xVl3boVw==",
       "dev": true
+    },
+    "element-size": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/element-size/-/element-size-1.1.1.tgz",
+      "integrity": "sha512-eaN+GMOq/Q+BIWy0ybsgpcYImjGIdNLyjLFJU4XsLHXYQao5jCNb36GyN6C2qwmDDYSfIBmKpPpr4VnBdLCsPQ=="
+    },
+    "elementary-circuits-directed-graph": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/elementary-circuits-directed-graph/-/elementary-circuits-directed-graph-1.3.1.tgz",
+      "integrity": "sha512-ZEiB5qkn2adYmpXGnJKkxT8uJHlW/mxmBpmeqawEHzPxh9HkLD4/1mFYX5l0On+f6rcPIt8/EWlRU2Vo3fX6dQ==",
+      "requires": {
+        "strongly-connected-components": "^1.0.1"
+      }
     },
     "elliptic": {
       "version": "6.5.4",
@@ -32932,7 +35247,6 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "dev": true,
       "requires": {
         "once": "^1.4.0"
       }
@@ -33045,7 +35359,6 @@
       "version": "0.10.53",
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
       "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
-      "dev": true,
       "requires": {
         "es6-iterator": "~2.0.3",
         "es6-symbol": "~3.1.3",
@@ -33056,7 +35369,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
-      "dev": true,
       "requires": {
         "d": "1",
         "es5-ext": "^0.10.35",
@@ -33067,10 +35379,20 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
       "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
-      "dev": true,
       "requires": {
         "d": "^1.0.1",
         "ext": "^1.1.2"
+      }
+    },
+    "es6-weak-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
+      "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.46",
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.1"
       }
     },
     "escalade": {
@@ -33644,8 +35966,7 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "esquery": {
       "version": "1.4.0",
@@ -33680,8 +36001,7 @@
     "esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "dev": true
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
     },
     "etag": {
       "version": "1.8.1",
@@ -33698,8 +36018,7 @@
     "events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "dev": true
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
     },
     "eventsource": {
       "version": "1.1.0",
@@ -33953,7 +36272,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/ext/-/ext-1.6.0.tgz",
       "integrity": "sha512-sdBImtzkq2HpkdRLtlLWDa6w4DX22ijZLKx8BMPUuKe1c5lbN6xwQDQCxSfxBQnHZ13ls/FH0MQZx/q/gr6FQg==",
-      "dev": true,
       "requires": {
         "type": "^2.5.0"
       },
@@ -33961,8 +36279,7 @@
         "type": {
           "version": "2.6.0",
           "resolved": "https://registry.npmjs.org/type/-/type-2.6.0.tgz",
-          "integrity": "sha512-eiDBDOmkih5pMbo9OqsqPRGMljLodLcwd5XD5JbtNB0o89xZAwynY9EdCDsJU7LtcVCClu9DvM7/0Ep1hYX3EQ==",
-          "dev": true
+          "integrity": "sha512-eiDBDOmkih5pMbo9OqsqPRGMljLodLcwd5XD5JbtNB0o89xZAwynY9EdCDsJU7LtcVCClu9DvM7/0Ep1hYX3EQ=="
         }
       }
     },
@@ -34018,6 +36335,22 @@
         }
       }
     },
+    "falafel": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/falafel/-/falafel-2.2.5.tgz",
+      "integrity": "sha512-HuC1qF9iTnHDnML9YZAdCDQwT0yKl/U55K4XSUXqGAA2GLoafFgWRqdAbhWJxXaYD4pyoVxAJ8wH670jMpI9DQ==",
+      "requires": {
+        "acorn": "^7.1.1",
+        "isarray": "^2.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+        }
+      }
+    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -34043,6 +36376,14 @@
         "micromatch": "^4.0.4"
       }
     },
+    "fast-isnumeric": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/fast-isnumeric/-/fast-isnumeric-1.1.4.tgz",
+      "integrity": "sha512-1mM8qOr2LYz8zGaUdmiqRDiuue00Dxjgcb1NQR7TnhLVh6sQyngP9xvLo7Sl7LZpP/sk5eb+bcyWXw530NTBZw==",
+      "requires": {
+        "is-string-blank": "^1.0.1"
+      }
+    },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -34051,8 +36392,7 @@
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-      "dev": true
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "fastq": {
       "version": "1.13.0",
@@ -34215,6 +36555,19 @@
       "integrity": "sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg==",
       "dev": true
     },
+    "flatten-vertex-data": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/flatten-vertex-data/-/flatten-vertex-data-1.0.2.tgz",
+      "integrity": "sha512-BvCBFK2NZqerFTdMDgqfHBwxYWnxeCkwONsw6PvBMcUXqo8U/KDWwmXhqx1x2kLIg7DqIsJfOaJFOmlua3Lxuw==",
+      "requires": {
+        "dtype": "^2.0.0"
+      }
+    },
+    "flip-pixels": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/flip-pixels/-/flip-pixels-1.0.2.tgz",
+      "integrity": "sha512-oXbJGbjDnfJRWPC7Va38EFhd+A8JWE5/hCiKcK8qjCdbLj9DTpsq6MEudwpRTH+V4qq+Jw7d3pUgQdSr3x3mTA=="
+    },
     "flush-write-stream": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
@@ -34230,6 +36583,22 @@
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
       "integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA==",
       "dev": true
+    },
+    "font-atlas": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/font-atlas/-/font-atlas-2.1.0.tgz",
+      "integrity": "sha512-kP3AmvX+HJpW4w3d+PiPR2X6E1yvsBXt2yhuCw+yReO9F1WYhvZwx3c95DGZGwg9xYzDGrgJYa885xmVA+28Cg==",
+      "requires": {
+        "css-font": "^1.0.0"
+      }
+    },
+    "font-measure": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/font-measure/-/font-measure-1.2.2.tgz",
+      "integrity": "sha512-mRLEpdrWzKe9hbfaF3Qpr06TAjquuBVP5cHy4b3hyeNdjc9i0PO6HniGsX5vjL5OWv7+Bd++NiooNpT/s8BvIA==",
+      "requires": {
+        "css-font": "^1.2.0"
+      }
     },
     "for-in": {
       "version": "1.0.2",
@@ -34461,7 +36830,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
       "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
-      "dev": true,
       "requires": {
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0"
@@ -34516,8 +36884,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -34548,11 +36915,21 @@
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
       "dev": true
     },
+    "geojson-vt": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-3.2.1.tgz",
+      "integrity": "sha512-EvGQQi/zPrDA6zr6BnJD/YhwAkBP8nnJ9emh3EnHQKVMfg/MRVtPbMYdgVy/IaEmn4UfagD2a6fafPDL5hbtwg=="
+    },
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
+    },
+    "get-canvas-context": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-canvas-context/-/get-canvas-context-1.0.2.tgz",
+      "integrity": "sha512-LnpfLf/TNzr9zVOGiIY6aKCz8EKuXmlYNV7CM2pUjBa/B+c2I15tS7KLySep75+FuerJdmArvJLcsAXWEy2H0A=="
     },
     "get-intrinsic": {
       "version": "1.1.1",
@@ -34601,6 +36978,54 @@
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
       "dev": true
+    },
+    "gl-mat4": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gl-mat4/-/gl-mat4-1.2.0.tgz",
+      "integrity": "sha512-sT5C0pwB1/e9G9AvAoLsoaJtbMGjfd/jfxo8jMCKqYYEnjZuFvqV5rehqar0538EmssjdDeiEWnKyBSTw7quoA=="
+    },
+    "gl-matrix": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.3.tgz",
+      "integrity": "sha512-wcCp8vu8FT22BnvKVPjXa/ICBWRq/zjFfdofZy1WSpQZpphblv12/bOQLBC1rMM7SGOFS9ltVmKOHil5+Ml7gA=="
+    },
+    "gl-text": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/gl-text/-/gl-text-1.3.1.tgz",
+      "integrity": "sha512-/f5gcEMiZd+UTBJLTl3D+CkCB/0UFGTx3nflH8ZmyWcLkZhsZ1+Xx5YYkw2rgWAzgPeE35xCqBuHSoMKQVsR+w==",
+      "requires": {
+        "bit-twiddle": "^1.0.2",
+        "color-normalize": "^1.5.0",
+        "css-font": "^1.2.0",
+        "detect-kerning": "^2.1.2",
+        "es6-weak-map": "^2.0.3",
+        "flatten-vertex-data": "^1.0.2",
+        "font-atlas": "^2.1.0",
+        "font-measure": "^1.2.2",
+        "gl-util": "^3.1.2",
+        "is-plain-obj": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "parse-rect": "^1.2.0",
+        "parse-unit": "^1.0.1",
+        "pick-by-alias": "^1.2.0",
+        "regl": "^2.0.0",
+        "to-px": "^1.0.1",
+        "typedarray-pool": "^1.1.0"
+      }
+    },
+    "gl-util": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/gl-util/-/gl-util-3.1.3.tgz",
+      "integrity": "sha512-dvRTggw5MSkJnCbh74jZzSoTOGnVYK+Bt+Ckqm39CVcl6+zSsxqWk4lr5NKhkqXHL6qvZAU9h17ZF8mIskY9mA==",
+      "requires": {
+        "is-browser": "^2.0.1",
+        "is-firefox": "^1.0.3",
+        "is-plain-obj": "^1.1.0",
+        "number-is-integer": "^1.0.1",
+        "object-assign": "^4.1.0",
+        "pick-by-alias": "^1.2.0",
+        "weak-map": "^1.0.5"
+      }
     },
     "glob": {
       "version": "7.2.0",
@@ -34676,11 +37101,184 @@
         "slash": "^3.0.0"
       }
     },
+    "glsl-inject-defines": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/glsl-inject-defines/-/glsl-inject-defines-1.0.3.tgz",
+      "integrity": "sha512-W49jIhuDtF6w+7wCMcClk27a2hq8znvHtlGnrYkSWEr8tHe9eA2dcnohlcAmxLYBSpSSdzOkRdyPTrx9fw49+A==",
+      "requires": {
+        "glsl-token-inject-block": "^1.0.0",
+        "glsl-token-string": "^1.0.1",
+        "glsl-tokenizer": "^2.0.2"
+      }
+    },
+    "glsl-resolve": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/glsl-resolve/-/glsl-resolve-0.0.1.tgz",
+      "integrity": "sha512-xxFNsfnhZTK9NBhzJjSBGX6IOqYpvBHxxmo+4vapiljyGNCY0Bekzn0firQkQrazK59c1hYxMDxYS8MDlhw4gA==",
+      "requires": {
+        "resolve": "^0.6.1",
+        "xtend": "^2.1.2"
+      },
+      "dependencies": {
+        "resolve": {
+          "version": "0.6.3",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.6.3.tgz",
+          "integrity": "sha512-UHBY3viPlJKf85YijDUcikKX6tmF4SokIDp518ZDVT92JNDcG5uKIthaT/owt3Sar0lwtOafsQuwrg22/v2Dwg=="
+        },
+        "xtend": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.2.0.tgz",
+          "integrity": "sha512-SLt5uylT+4aoXxXuwtQp5ZnMMzhDb1Xkg4pEqc00WUJCQifPfV9Ub1VrNhp9kXkrjZD2I2Hl8WnjP37jzZLPZw=="
+        }
+      }
+    },
+    "glsl-token-assignments": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/glsl-token-assignments/-/glsl-token-assignments-2.0.2.tgz",
+      "integrity": "sha512-OwXrxixCyHzzA0U2g4btSNAyB2Dx8XrztY5aVUCjRSh4/D0WoJn8Qdps7Xub3sz6zE73W3szLrmWtQ7QMpeHEQ=="
+    },
+    "glsl-token-defines": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/glsl-token-defines/-/glsl-token-defines-1.0.0.tgz",
+      "integrity": "sha512-Vb5QMVeLjmOwvvOJuPNg3vnRlffscq2/qvIuTpMzuO/7s5kT+63iL6Dfo2FYLWbzuiycWpbC0/KV0biqFwHxaQ==",
+      "requires": {
+        "glsl-tokenizer": "^2.0.0"
+      }
+    },
+    "glsl-token-depth": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/glsl-token-depth/-/glsl-token-depth-1.1.2.tgz",
+      "integrity": "sha512-eQnIBLc7vFf8axF9aoi/xW37LSWd2hCQr/3sZui8aBJnksq9C7zMeUYHVJWMhFzXrBU7fgIqni4EhXVW4/krpg=="
+    },
+    "glsl-token-descope": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/glsl-token-descope/-/glsl-token-descope-1.0.2.tgz",
+      "integrity": "sha512-kS2PTWkvi/YOeicVjXGgX5j7+8N7e56srNDEHDTVZ1dcESmbmpmgrnpjPcjxJjMxh56mSXYoFdZqb90gXkGjQw==",
+      "requires": {
+        "glsl-token-assignments": "^2.0.0",
+        "glsl-token-depth": "^1.1.0",
+        "glsl-token-properties": "^1.0.0",
+        "glsl-token-scope": "^1.1.0"
+      }
+    },
+    "glsl-token-inject-block": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/glsl-token-inject-block/-/glsl-token-inject-block-1.1.0.tgz",
+      "integrity": "sha512-q/m+ukdUBuHCOtLhSr0uFb/qYQr4/oKrPSdIK2C4TD+qLaJvqM9wfXIF/OOBjuSA3pUoYHurVRNao6LTVVUPWA=="
+    },
+    "glsl-token-properties": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/glsl-token-properties/-/glsl-token-properties-1.0.1.tgz",
+      "integrity": "sha512-dSeW1cOIzbuUoYH0y+nxzwK9S9O3wsjttkq5ij9ZGw0OS41BirKJzzH48VLm8qLg+au6b0sINxGC0IrGwtQUcA=="
+    },
+    "glsl-token-scope": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/glsl-token-scope/-/glsl-token-scope-1.1.2.tgz",
+      "integrity": "sha512-YKyOMk1B/tz9BwYUdfDoHvMIYTGtVv2vbDSLh94PT4+f87z21FVdou1KNKgF+nECBTo0fJ20dpm0B1vZB1Q03A=="
+    },
+    "glsl-token-string": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/glsl-token-string/-/glsl-token-string-1.0.1.tgz",
+      "integrity": "sha512-1mtQ47Uxd47wrovl+T6RshKGkRRCYWhnELmkEcUAPALWGTFe2XZpH3r45XAwL2B6v+l0KNsCnoaZCSnhzKEksg=="
+    },
+    "glsl-token-whitespace-trim": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/glsl-token-whitespace-trim/-/glsl-token-whitespace-trim-1.0.0.tgz",
+      "integrity": "sha512-ZJtsPut/aDaUdLUNtmBYhaCmhIjpKNg7IgZSfX5wFReMc2vnj8zok+gB/3Quqs0TsBSX/fGnqUUYZDqyuc2xLQ=="
+    },
+    "glsl-tokenizer": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/glsl-tokenizer/-/glsl-tokenizer-2.1.5.tgz",
+      "integrity": "sha512-XSZEJ/i4dmz3Pmbnpsy3cKh7cotvFlBiZnDOwnj/05EwNp2XrhQ4XKJxT7/pDt4kp4YcpRSKz8eTV7S+mwV6MA==",
+      "requires": {
+        "through2": "^0.6.3"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ=="
+        },
+        "through2": {
+          "version": "0.6.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "integrity": "sha512-RkK/CCESdTKQZHdmKICijdKKsCRVHs5KsLZ6pACAmF/1GPUQhonHSXWNERctxEp7RmvjdNbZTL5z9V7nSCXKcg==",
+          "requires": {
+            "readable-stream": ">=1.0.33-1 <1.1.0-0",
+            "xtend": ">=4.0.0 <4.1.0-0"
+          }
+        }
+      }
+    },
+    "glslify": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/glslify/-/glslify-7.1.1.tgz",
+      "integrity": "sha512-bud98CJ6kGZcP9Yxcsi7Iz647wuDz3oN+IZsjCRi5X1PI7t/xPKeL0mOwXJjo+CRZMqvq0CkSJiywCcY7kVYog==",
+      "requires": {
+        "bl": "^2.2.1",
+        "concat-stream": "^1.5.2",
+        "duplexify": "^3.4.5",
+        "falafel": "^2.1.0",
+        "from2": "^2.3.0",
+        "glsl-resolve": "0.0.1",
+        "glsl-token-whitespace-trim": "^1.0.0",
+        "glslify-bundle": "^5.0.0",
+        "glslify-deps": "^1.2.5",
+        "minimist": "^1.2.5",
+        "resolve": "^1.1.5",
+        "stack-trace": "0.0.9",
+        "static-eval": "^2.0.5",
+        "through2": "^2.0.1",
+        "xtend": "^4.0.0"
+      }
+    },
+    "glslify-bundle": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/glslify-bundle/-/glslify-bundle-5.1.1.tgz",
+      "integrity": "sha512-plaAOQPv62M1r3OsWf2UbjN0hUYAB7Aph5bfH58VxJZJhloRNbxOL9tl/7H71K7OLJoSJ2ZqWOKk3ttQ6wy24A==",
+      "requires": {
+        "glsl-inject-defines": "^1.0.1",
+        "glsl-token-defines": "^1.0.0",
+        "glsl-token-depth": "^1.1.1",
+        "glsl-token-descope": "^1.0.2",
+        "glsl-token-scope": "^1.1.1",
+        "glsl-token-string": "^1.0.1",
+        "glsl-token-whitespace-trim": "^1.0.0",
+        "glsl-tokenizer": "^2.0.2",
+        "murmurhash-js": "^1.0.0",
+        "shallow-copy": "0.0.1"
+      }
+    },
+    "glslify-deps": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/glslify-deps/-/glslify-deps-1.3.2.tgz",
+      "integrity": "sha512-7S7IkHWygJRjcawveXQjRXLO2FTjijPDYC7QfZyAQanY+yGLCFHYnPtsGT9bdyHiwPTw/5a1m1M9hamT2aBpag==",
+      "requires": {
+        "@choojs/findup": "^0.2.0",
+        "events": "^3.2.0",
+        "glsl-resolve": "0.0.1",
+        "glsl-tokenizer": "^2.0.0",
+        "graceful-fs": "^4.1.2",
+        "inherits": "^2.0.1",
+        "map-limit": "0.0.1",
+        "resolve": "^1.0.0"
+      }
+    },
     "graceful-fs": {
       "version": "4.2.9",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
-      "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==",
-      "dev": true
+      "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ=="
     },
     "graphql": {
       "version": "15.8.0",
@@ -34696,6 +37294,11 @@
       "requires": {
         "tslib": "^2.1.0"
       }
+    },
+    "grid-index": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/grid-index/-/grid-index-1.1.0.tgz",
+      "integrity": "sha512-HZRwumpOGUrHyxO5bqKZL0B0GlUpwtCAzZ42sgxUPniu33R1LSFH5yrIcBCHjkctCAh3mtWKcKd9J4vDDdeVHA=="
     },
     "growly": {
       "version": "1.3.0",
@@ -34730,7 +37333,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -34746,6 +37348,22 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true
+    },
+    "has-hover": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-hover/-/has-hover-1.0.1.tgz",
+      "integrity": "sha512-0G6w7LnlcpyDzpeGUTuT0CEw05+QlMuGVk1IHNAlHrGJITGodjZu3x8BNDUMfKJSZXNB2ZAclqc1bvrd+uUpfg==",
+      "requires": {
+        "is-browser": "^2.0.1"
+      }
+    },
+    "has-passive-events": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-passive-events/-/has-passive-events-1.0.0.tgz",
+      "integrity": "sha512-2vSj6IeIsgvsRMyeQ0JaCX5Q3lX4zMn5HpoVc7MEhQ6pv8Iq9rsXjsp+E5ZwaT7T0xhMT0KmU8gtt1EFVdbJiw==",
+      "requires": {
+        "is-browser": "^2.0.1"
+      }
     },
     "has-symbols": {
       "version": "1.0.2",
@@ -34941,6 +37559,11 @@
       "resolved": "https://registry.npmjs.org/hsla-regex/-/hsla-regex-1.0.0.tgz",
       "integrity": "sha1-wc56MWjIxmFAM6S194d/OyJfnDg=",
       "dev": true
+    },
+    "hsluv": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/hsluv/-/hsluv-0.0.3.tgz",
+      "integrity": "sha512-08iL2VyCRbkQKBySkSh6m8zMUa3sADAxGVWs3Z1aPcUkTJeK0ETG4Fc27tEmQBGUAXZjIsXOZqBvacuVNSC/fQ=="
     },
     "html-encoding-sniffer": {
       "version": "2.0.1",
@@ -35231,7 +37854,6 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -35287,8 +37909,7 @@
     "ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
     "iferr": {
       "version": "0.1.5",
@@ -35301,6 +37922,16 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
       "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
       "dev": true
+    },
+    "image-palette": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/image-palette/-/image-palette-2.1.0.tgz",
+      "integrity": "sha512-3ImSEWD26+xuQFdP0RWR4WSXadZwvgrFhjGNpMEapTG1tf2XrBFS2dlKK5hNgH4UIaSQlSUFRn1NeA+zULIWbQ==",
+      "requires": {
+        "color-id": "^1.1.0",
+        "pxls": "^2.0.0",
+        "quantize": "^1.0.2"
+      }
     },
     "immer": {
       "version": "8.0.1",
@@ -35465,8 +38096,7 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ini": {
       "version": "1.3.8",
@@ -35544,6 +38174,11 @@
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
+    "is-base64": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-base64/-/is-base64-0.1.0.tgz",
+      "integrity": "sha512-WRRyllsGXJM7ZN7gPTCCQ/6wNPTRDwiWdPK66l5sJzcU/oOzcIcRRf0Rux8bkpox/1yjt0F6VJRsQOIG2qz5sg=="
+    },
     "is-bigint": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
@@ -35563,6 +38198,11 @@
         "binary-extensions": "^2.0.0"
       }
     },
+    "is-blob": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-blob/-/is-blob-2.1.0.tgz",
+      "integrity": "sha512-SZ/fTft5eUhQM6oF/ZaASFDEdbFVe89Imltn9uZr03wdKMcWNVYSMjQPFtg05QuNkt5l5c135ElvXEQG0rk4tw=="
+    },
     "is-boolean-object": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
@@ -35572,6 +38212,11 @@
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
       }
+    },
+    "is-browser": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-browser/-/is-browser-2.1.0.tgz",
+      "integrity": "sha512-F5rTJxDQ2sW81fcfOR1GnCXT6sVJC104fCyfj+mjpwNEwaPYSn5fte5jiHmBg3DHsIoL/l8Kvw5VN5SsTRcRFQ=="
     },
     "is-buffer": {
       "version": "1.1.6",
@@ -35629,7 +38274,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
       "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
-      "dev": true,
       "requires": {
         "has": "^1.0.3"
       }
@@ -35690,6 +38334,21 @@
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
       "dev": true
     },
+    "is-finite": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
+      "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w=="
+    },
+    "is-firefox": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-firefox/-/is-firefox-1.0.3.tgz",
+      "integrity": "sha512-6Q9ITjvWIm0Xdqv+5U12wgOKEM2KoBw4Y926m0OFkvlCxnbG94HKAsVz8w3fWcfAS5YA2fJORXX1dLrkprCCxA=="
+    },
+    "is-float-array": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-float-array/-/is-float-array-1.0.0.tgz",
+      "integrity": "sha512-4ew1Sx6B6kEAl3T3NOM0yB94J3NZnBdNt4paw0e8nY73yHHTeTEhyQ3Lj7EQEnv5LD+GxNTaT4L46jcKjjpLiQ=="
+    },
     "is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -35711,11 +38370,21 @@
         "is-extglob": "^2.1.1"
       }
     },
+    "is-iexplorer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-iexplorer/-/is-iexplorer-1.0.0.tgz",
+      "integrity": "sha512-YeLzceuwg3K6O0MLM3UyUUjKAlyULetwryFp1mHy1I5PfArK0AEqlfa+MR4gkJjcbuJXoDJCvXbyqZVf5CR2Sg=="
+    },
     "is-in-browser": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/is-in-browser/-/is-in-browser-1.1.3.tgz",
       "integrity": "sha1-Vv9NtoOgeMYILrldrX3GLh0E+DU=",
       "dev": true
+    },
+    "is-mobile": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-mobile/-/is-mobile-2.2.2.tgz",
+      "integrity": "sha512-wW/SXnYJkTjs++tVK5b6kVITZpAZPtUrt9SF80vvxGiF/Oywal+COk1jlRkiVq15RFNEQKQY31TkV24/1T5cVg=="
     },
     "is-module": {
       "version": "1.0.0",
@@ -35747,8 +38416,7 @@
     "is-obj": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
-      "dev": true
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
     },
     "is-path-cwd": {
       "version": "2.2.0",
@@ -35777,8 +38445,7 @@
     "is-plain-obj": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
-      "dev": true
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
     },
     "is-plain-object": {
       "version": "2.0.4",
@@ -35853,6 +38520,16 @@
         "has-tostringtag": "^1.0.0"
       }
     },
+    "is-string-blank": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-string-blank/-/is-string-blank-1.0.1.tgz",
+      "integrity": "sha512-9H+ZBCVs3L9OYqv8nuUAzpcT9OTgMD1yAWrG7ihlnibdkbtB850heAmYWxHuXc4CHy4lKeK69tN+ny1K7gBIrw=="
+    },
+    "is-svg-path": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-svg-path/-/is-svg-path-1.0.2.tgz",
+      "integrity": "sha512-Lj4vePmqpPR1ZnRctHv8ltSh1OrSxHkhUkd7wi+VQdcdP15/KvQFyk7LhNuM7ZW0EVbJz8kZLVmL9quLrfq4Kg=="
+    },
     "is-symbol": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
@@ -35895,8 +38572,7 @@
     "isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-      "peer": true
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
     },
     "isexe": {
       "version": "2.0.0",
@@ -36794,6 +39470,11 @@
         "object.assign": "^4.1.2"
       }
     },
+    "kdbush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-3.0.0.tgz",
+      "integrity": "sha512-hRkd6/XW4HTsA9vjVpY9tuXJYLSlelnkTmVFu4M9/7MIYQtFcHpbugAU7UbOfjOiVSVYl2fqgBuJ32JUmRo5Ew=="
+    },
     "killable": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/killable/-/killable-1.0.1.tgz",
@@ -36931,8 +39612,7 @@
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
     "lodash.template": {
       "version": "4.5.0",
@@ -37045,6 +39725,24 @@
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
       "dev": true
     },
+    "map-limit": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/map-limit/-/map-limit-0.0.1.tgz",
+      "integrity": "sha512-pJpcfLPnIF/Sk3taPW21G/RQsEEirGaFpCW3oXRwH9dnFHPHNGjNyvh++rdmC2fNqEaTw2MhYJraoJWAHx8kEg==",
+      "requires": {
+        "once": "~1.3.0"
+      },
+      "dependencies": {
+        "once": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+          "integrity": "sha512-6vaNInhu+CHxtONf3zw3vq4SP2DOQhjBvIa3rNcG0+P7eKWlYH6Peu7rHizSloRU2EwMz6GraLieis9Ac9+p1w==",
+          "requires": {
+            "wrappy": "1"
+          }
+        }
+      }
+    },
     "map-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
@@ -37053,6 +39751,41 @@
       "requires": {
         "object-visit": "^1.0.0"
       }
+    },
+    "mapbox-gl": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.10.1.tgz",
+      "integrity": "sha512-0aHt+lFUpYfvh0kMIqXqNXqoYMuhuAsMlw87TbhWrw78Tx2zfuPI0Lx31/YPUgJ+Ire0tzQ4JnuBL7acDNXmMg==",
+      "requires": {
+        "@mapbox/geojson-rewind": "^0.5.0",
+        "@mapbox/geojson-types": "^1.0.2",
+        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
+        "@mapbox/mapbox-gl-supported": "^1.5.0",
+        "@mapbox/point-geometry": "^0.1.0",
+        "@mapbox/tiny-sdf": "^1.1.1",
+        "@mapbox/unitbezier": "^0.0.0",
+        "@mapbox/vector-tile": "^1.3.1",
+        "@mapbox/whoots-js": "^3.1.0",
+        "csscolorparser": "~1.0.3",
+        "earcut": "^2.2.2",
+        "geojson-vt": "^3.2.1",
+        "gl-matrix": "^3.2.1",
+        "grid-index": "^1.1.0",
+        "minimist": "^1.2.5",
+        "murmurhash-js": "^1.0.0",
+        "pbf": "^3.2.1",
+        "potpack": "^1.0.1",
+        "quickselect": "^2.0.0",
+        "rw": "^1.3.3",
+        "supercluster": "^7.0.0",
+        "tinyqueue": "^2.0.3",
+        "vt-pbf": "^3.1.1"
+      }
+    },
+    "math-log2": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/math-log2/-/math-log2-1.0.1.tgz",
+      "integrity": "sha512-9W0yGtkaMAkf74XGYVy4Dqw3YUMnTNB2eeiw9aQbUl4A3KmuCEHTt2DgAB07ENzOYAjsYSAYufkAq0Zd+jU7zA=="
     },
     "md5.js": {
       "version": "1.3.5",
@@ -37255,10 +39988,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g=="
     },
     "minipass": {
       "version": "3.1.6",
@@ -37343,6 +40075,34 @@
         "minimist": "^1.2.5"
       }
     },
+    "mouse-change": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/mouse-change/-/mouse-change-1.4.0.tgz",
+      "integrity": "sha512-vpN0s+zLL2ykyyUDh+fayu9Xkor5v/zRD9jhSqjRS1cJTGS0+oakVZzNm5n19JvvEj0you+MXlYTpNxUDQUjkQ==",
+      "requires": {
+        "mouse-event": "^1.0.0"
+      }
+    },
+    "mouse-event": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/mouse-event/-/mouse-event-1.0.5.tgz",
+      "integrity": "sha512-ItUxtL2IkeSKSp9cyaX2JLUuKk2uMoxBg4bbOWVd29+CskYJR9BGsUqtXenNzKbnDshvupjUewDIYVrOB6NmGw=="
+    },
+    "mouse-event-offset": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mouse-event-offset/-/mouse-event-offset-3.0.2.tgz",
+      "integrity": "sha512-s9sqOs5B1Ykox3Xo8b3Ss2IQju4UwlW6LSR+Q5FXWpprJ5fzMLefIIItr3PH8RwzfGy6gxs/4GAmiNuZScE25w=="
+    },
+    "mouse-wheel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mouse-wheel/-/mouse-wheel-1.2.0.tgz",
+      "integrity": "sha512-+OfYBiUOCTWcTECES49neZwL5AoGkXE+lFjIvzwNCnYRlso+EnfvovcBxGoyQ0yQt806eSPjS675K0EwWknXmw==",
+      "requires": {
+        "right-now": "^1.0.0",
+        "signum": "^1.0.0",
+        "to-px": "^1.0.1"
+      }
+    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -37371,8 +40131,7 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "multicast-dns": {
       "version": "6.2.3",
@@ -37395,6 +40154,19 @@
       "resolved": "https://registry.npmjs.org/multimap/-/multimap-1.1.0.tgz",
       "integrity": "sha512-0ZIR9PasPxGXmRsEF8jsDzndzHDj7tIav+JUmvIFB/WHswliFnquxECT/De7GR4yg99ky/NlRKJT82G1y271bw==",
       "dev": true
+    },
+    "mumath": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/mumath/-/mumath-3.3.4.tgz",
+      "integrity": "sha512-VAFIOG6rsxoc7q/IaY3jdjmrsuX9f15KlRLYTHmixASBZkZEKC1IFqE2BC5CdhXmK6WLM1Re33z//AGmeRI6FA==",
+      "requires": {
+        "almost-equal": "^1.1.0"
+      }
+    },
+    "murmurhash-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
+      "integrity": "sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw=="
     },
     "nan": {
       "version": "2.15.0",
@@ -37428,6 +40200,11 @@
         "to-regex": "^3.0.1"
       }
     },
+    "native-promise-only": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
+      "integrity": "sha512-zkVhZUA3y8mbz652WrL5x0fB0ehrBkulWT3TomAQ9iDtyXZvzKeEA6GPxAItBYeNYl5yngKRX612qHOhvMkDeg=="
+    },
     "native-url": {
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/native-url/-/native-url-0.2.6.tgz",
@@ -37442,6 +40219,26 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "needle": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.9.1.tgz",
+      "integrity": "sha512-6R9fqJ5Zcmf+uYaFgdIHmLwNldn5HbK8L5ybn7Uz+ylX/rnOsSp1AHcvQSrCaFN+qNM1wpymHqD7mVasEOlHGQ==",
+      "requires": {
+        "debug": "^3.2.6",
+        "iconv-lite": "^0.4.4",
+        "sax": "^1.2.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
     },
     "negotiator": {
       "version": "0.6.3",
@@ -37458,8 +40255,7 @@
     "next-tick": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
-      "dev": true
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
     },
     "nice-try": {
       "version": "1.0.5",
@@ -37581,6 +40377,11 @@
       "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
       "dev": true
     },
+    "normalize-svg-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-svg-path/-/normalize-svg-path-0.1.0.tgz",
+      "integrity": "sha512-1/kmYej2iedi5+ROxkRESL/pI02pkg0OBnaR4hJkSIX6+ORzepwbuUXfrdZaPjysTsJInj0Rj5NuX027+dMBvA=="
+    },
     "normalize-url": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
@@ -37616,6 +40417,14 @@
       "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
       "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=",
       "dev": true
+    },
+    "number-is-integer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-integer/-/number-is-integer-1.0.1.tgz",
+      "integrity": "sha512-Dq3iuiFBkrbmuQjGFFF3zckXNCQoSD37/SdSbgcBailUx6knDvDwb5CympBgcoWHy36sfS12u74MHYkXyHq6bg==",
+      "requires": {
+        "is-finite": "^1.0.1"
+      }
     },
     "nwsapi": {
       "version": "2.2.0",
@@ -37715,8 +40524,7 @@
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
     },
     "object-visit": {
       "version": "1.0.1",
@@ -37827,7 +40635,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -38026,6 +40833,11 @@
         "callsites": "^3.0.0"
       }
     },
+    "parenthesis": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/parenthesis/-/parenthesis-3.1.8.tgz",
+      "integrity": "sha512-KF/U8tk54BgQewkJPvB4s/US3VQY68BRDpH638+7O/n58TpnwiwnOtGIOsT2/i+M78s61BBpeC83STB88d8sqw=="
+    },
     "parse-asn1": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.6.tgz",
@@ -38050,6 +40862,24 @@
         "json-parse-even-better-errors": "^2.3.0",
         "lines-and-columns": "^1.1.6"
       }
+    },
+    "parse-rect": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/parse-rect/-/parse-rect-1.2.0.tgz",
+      "integrity": "sha512-4QZ6KYbnE6RTwg9E0HpLchUM9EZt6DnDxajFZZDSV4p/12ZJEvPO702DZpGvRYEPo00yKDys7jASi+/w7aO8LA==",
+      "requires": {
+        "pick-by-alias": "^1.2.0"
+      }
+    },
+    "parse-svg-path": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/parse-svg-path/-/parse-svg-path-0.1.2.tgz",
+      "integrity": "sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ=="
+    },
+    "parse-unit": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-unit/-/parse-unit-1.0.1.tgz",
+      "integrity": "sha512-hrqldJHokR3Qj88EIlV/kAyAi/G5R2+R56TBANxNMy0uPlYcttx0jnMW6Yx5KsKPSbC3KddM/7qQm3+0wEXKxg=="
     },
     "parse5": {
       "version": "6.0.1",
@@ -38118,8 +40948,7 @@
     "path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "path-to-regexp": {
       "version": "1.8.0",
@@ -38135,6 +40964,15 @@
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "dev": true
+    },
+    "pbf": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.2.1.tgz",
+      "integrity": "sha512-ClrV7pNOn7rtmoQVF4TS1vyU0WhYRnP92fzbfF75jAIwpnzdJXf8iTd4CMEqO4yUenH6NDqLiwjqlh6QgZzgLQ==",
+      "requires": {
+        "ieee754": "^1.1.12",
+        "resolve-protobuf-schema": "^2.1.0"
+      }
     },
     "pbkdf2": {
       "version": "3.1.2",
@@ -38152,8 +40990,12 @@
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-      "dev": true
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
+    "pick-by-alias": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pick-by-alias/-/pick-by-alias-1.2.0.tgz",
+      "integrity": "sha512-ESj2+eBxhGrcA1azgHs7lARG5+5iLakc/6nlfbpjcLl00HuuUOIuORhYXN4D1HfvMSKuVtFQjAlnwi1JHEeDIw=="
     },
     "picocolors": {
       "version": "1.0.0",
@@ -38302,6 +41144,62 @@
         }
       }
     },
+    "plotly.js": {
+      "version": "2.17.1",
+      "resolved": "https://registry.npmjs.org/plotly.js/-/plotly.js-2.17.1.tgz",
+      "integrity": "sha512-Tgjk1FrA4TIJAMEFlJqq9swyRsdwKas90DNHoV6MZ+uxmcEO7O/kdEonu9LEIrmiNiuIQgGxwNERH7jrJxjAlQ==",
+      "requires": {
+        "@plotly/d3": "3.8.0",
+        "@plotly/d3-sankey": "0.7.2",
+        "@plotly/d3-sankey-circular": "0.33.1",
+        "@turf/area": "^6.4.0",
+        "@turf/bbox": "^6.4.0",
+        "@turf/centroid": "^6.0.2",
+        "canvas-fit": "^1.5.0",
+        "color-alpha": "1.0.4",
+        "color-normalize": "1.5.0",
+        "color-parse": "1.3.8",
+        "color-rgba": "2.1.1",
+        "country-regex": "^1.1.0",
+        "d3-force": "^1.2.1",
+        "d3-format": "^1.4.5",
+        "d3-geo": "^1.12.1",
+        "d3-geo-projection": "^2.9.0",
+        "d3-hierarchy": "^1.1.9",
+        "d3-interpolate": "^1.4.0",
+        "d3-time": "^1.1.0",
+        "d3-time-format": "^2.2.3",
+        "fast-isnumeric": "^1.1.4",
+        "gl-mat4": "^1.2.0",
+        "gl-text": "^1.3.1",
+        "glslify": "^7.1.1",
+        "has-hover": "^1.0.1",
+        "has-passive-events": "^1.0.0",
+        "is-mobile": "^2.2.2",
+        "mapbox-gl": "1.10.1",
+        "mouse-change": "^1.4.0",
+        "mouse-event-offset": "^3.0.2",
+        "mouse-wheel": "^1.2.0",
+        "native-promise-only": "^0.8.1",
+        "parse-svg-path": "^0.1.2",
+        "point-in-polygon": "^1.1.0",
+        "polybooljs": "^1.2.0",
+        "probe-image-size": "^7.2.3",
+        "regl": "npm:@plotly/regl@^2.1.2",
+        "regl-error2d": "^2.0.12",
+        "regl-line2d": "^3.1.2",
+        "regl-scatter2d": "^3.2.8",
+        "regl-splom": "^1.0.14",
+        "strongly-connected-components": "^1.0.1",
+        "superscript-text": "^1.0.0",
+        "svg-path-sdf": "^1.1.3",
+        "tinycolor2": "^1.4.2",
+        "to-px": "1.0.1",
+        "topojson-client": "^3.1.0",
+        "webgl-context": "^2.2.0",
+        "world-calendars": "^1.0.3"
+      }
+    },
     "pluralize": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
@@ -38316,6 +41214,16 @@
       "requires": {
         "ts-pnp": "^1.1.6"
       }
+    },
+    "point-in-polygon": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/point-in-polygon/-/point-in-polygon-1.1.0.tgz",
+      "integrity": "sha512-3ojrFwjnnw8Q9242TzgXuTD+eKiutbzyslcq1ydfu82Db2y+Ogbmyrkpv0Hgj31qwT3lbS9+QAAO/pIQM35XRw=="
+    },
+    "polybooljs": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/polybooljs/-/polybooljs-1.2.0.tgz",
+      "integrity": "sha512-mKjR5nolISvF+q2BtC1fi/llpxBPTQ3wLWN8+ldzdw2Hocpc8C72ZqnamCM4Z6z+68GVVjkeM01WJegQmZ8MEQ=="
     },
     "popper.js": {
       "version": "1.16.1-lts",
@@ -40991,6 +43899,11 @@
         "uniq": "^1.0.1"
       }
     },
+    "potpack": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.2.tgz",
+      "integrity": "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ=="
+    },
     "prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -41046,6 +43959,16 @@
         "react-is": "^17.0.1"
       }
     },
+    "probe-image-size": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/probe-image-size/-/probe-image-size-7.2.3.tgz",
+      "integrity": "sha512-HubhG4Rb2UH8YtV4ba0Vp5bQ7L78RTONYu/ujmCu5nBI8wGv24s4E9xSKBi0N1MowRpxk76pFCpJtW0KPzOK0w==",
+      "requires": {
+        "lodash.merge": "^4.6.2",
+        "needle": "^2.5.2",
+        "stream-parser": "~0.3.1"
+      }
+    },
     "process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -41055,8 +43978,7 @@
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "progress": {
       "version": "2.0.3",
@@ -41111,6 +44033,11 @@
           "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         }
       }
+    },
+    "protocol-buffers-schema": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
+      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw=="
     },
     "proxy-addr": {
       "version": "2.0.7",
@@ -41195,6 +44122,26 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
     },
+    "pxls": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/pxls/-/pxls-2.3.2.tgz",
+      "integrity": "sha512-pQkwgbLqWPcuES5iEmGa10OlCf5xG0blkIF3dg7PpRZShbTYcvAdfFfGL03SMrkaSUaa/V0UpN9HWg40O2AIIw==",
+      "requires": {
+        "arr-flatten": "^1.1.0",
+        "compute-dims": "^1.1.0",
+        "flip-pixels": "^1.0.2",
+        "is-browser": "^2.1.0",
+        "is-buffer": "^2.0.3",
+        "to-uint8": "^1.4.1"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+          "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="
+        }
+      }
+    },
     "q": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
@@ -41206,6 +44153,11 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.6.tgz",
       "integrity": "sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ==",
       "dev": true
+    },
+    "quantize": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/quantize/-/quantize-1.0.2.tgz",
+      "integrity": "sha512-25P7wI2UoDbIQsQp50ARkt+5pwPsOq7G/BqvT5xAbapnRoNWMN8/p55H9TXd5MuENiJnm5XICB2H2aDZGwts7w=="
     },
     "query-string": {
       "version": "4.3.4",
@@ -41241,11 +44193,15 @@
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true
     },
+    "quickselect": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
+      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="
+    },
     "raf": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
       "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
-      "dev": true,
       "requires": {
         "performance-now": "^2.1.0"
       }
@@ -41556,6 +44512,14 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+    },
+    "react-plotly.js": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/react-plotly.js/-/react-plotly.js-2.6.0.tgz",
+      "integrity": "sha512-g93xcyhAVCSt9kV1svqG1clAEdL6k3U+jjuSzfTV7owaSU9Go6Ph8bl25J+jKfKvIGAEYpe4qj++WHJuc9IaeA==",
+      "requires": {
+        "prop-types": "^15.8.1"
+      }
     },
     "react-redux": {
       "version": "7.2.6",
@@ -41898,7 +44862,6 @@
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
       "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-      "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -41912,14 +44875,12 @@
         "isarray": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "string_decoder": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -42030,6 +44991,11 @@
       "integrity": "sha512-jbD/FT0+9MBU2XAZluI7w2OBs1RBi6p9M83nkoZayQXXU9e8Robt69FcZc7wU4eJD/YFTjn1JdCk3rbMJajz8Q==",
       "dev": true
     },
+    "regex-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/regex-regex/-/regex-regex-1.0.0.tgz",
+      "integrity": "sha512-FPbEhFTLpxKNgHKay3zMfkHzFK2ebViAlyvsz5euO4kwekH0T6fAL4Sdo2CgQ7Y1tGB5HqQm8SBq7pW5GegvVA=="
+    },
     "regexp-tree": {
       "version": "0.1.24",
       "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.24.tgz",
@@ -42087,6 +45053,82 @@
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
           "dev": true
         }
+      }
+    },
+    "regl": {
+      "version": "npm:@plotly/regl@2.1.2",
+      "resolved": "https://registry.npmjs.org/@plotly/regl/-/regl-2.1.2.tgz",
+      "integrity": "sha512-Mdk+vUACbQvjd0m/1JJjOOafmkp/EpmHjISsopEz5Av44CBq7rPC05HHNbYGKVyNUF2zmEoBS/TT0pd0SPFFyw=="
+    },
+    "regl-error2d": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/regl-error2d/-/regl-error2d-2.0.12.tgz",
+      "integrity": "sha512-r7BUprZoPO9AbyqM5qlJesrSRkl+hZnVKWKsVp7YhOl/3RIpi4UDGASGJY0puQ96u5fBYw/OlqV24IGcgJ0McA==",
+      "requires": {
+        "array-bounds": "^1.0.1",
+        "color-normalize": "^1.5.0",
+        "flatten-vertex-data": "^1.0.2",
+        "object-assign": "^4.1.1",
+        "pick-by-alias": "^1.2.0",
+        "to-float32": "^1.1.0",
+        "update-diff": "^1.1.0"
+      }
+    },
+    "regl-line2d": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/regl-line2d/-/regl-line2d-3.1.2.tgz",
+      "integrity": "sha512-nmT7WWS/WxmXAQMkgaMKWXaVmwJ65KCrjbqHGOUjjqQi6shfT96YbBOvelXwO9hG7/hjvbzjtQ2UO0L3e7YaXQ==",
+      "requires": {
+        "array-bounds": "^1.0.1",
+        "array-find-index": "^1.0.2",
+        "array-normalize": "^1.1.4",
+        "color-normalize": "^1.5.0",
+        "earcut": "^2.1.5",
+        "es6-weak-map": "^2.0.3",
+        "flatten-vertex-data": "^1.0.2",
+        "glslify": "^7.0.0",
+        "object-assign": "^4.1.1",
+        "parse-rect": "^1.2.0",
+        "pick-by-alias": "^1.2.0",
+        "to-float32": "^1.1.0"
+      }
+    },
+    "regl-scatter2d": {
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/regl-scatter2d/-/regl-scatter2d-3.2.8.tgz",
+      "integrity": "sha512-bqrqJyeHkGBa9mEfuBnRd7FUtdtZ1l+gsM2C5Ugr1U3vJG5K3mdWdVWtOAllZ5FHHyWJV/vgjVvftgFUg6CDig==",
+      "requires": {
+        "@plotly/point-cluster": "^3.1.9",
+        "array-range": "^1.0.1",
+        "array-rearrange": "^2.2.2",
+        "clamp": "^1.0.1",
+        "color-id": "^1.1.0",
+        "color-normalize": "^1.5.0",
+        "color-rgba": "^2.1.1",
+        "flatten-vertex-data": "^1.0.2",
+        "glslify": "^7.0.0",
+        "image-palette": "^2.1.0",
+        "is-iexplorer": "^1.0.0",
+        "object-assign": "^4.1.1",
+        "parse-rect": "^1.2.0",
+        "pick-by-alias": "^1.2.0",
+        "to-float32": "^1.1.0",
+        "update-diff": "^1.1.0"
+      }
+    },
+    "regl-splom": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/regl-splom/-/regl-splom-1.0.14.tgz",
+      "integrity": "sha512-OiLqjmPRYbd7kDlHC6/zDf6L8lxgDC65BhC8JirhP4ykrK4x22ZyS+BnY8EUinXKDeMgmpRwCvUmk7BK4Nweuw==",
+      "requires": {
+        "array-bounds": "^1.0.1",
+        "array-range": "^1.0.1",
+        "color-alpha": "^1.0.4",
+        "flatten-vertex-data": "^1.0.2",
+        "parse-rect": "^1.2.0",
+        "pick-by-alias": "^1.2.0",
+        "raf": "^3.4.1",
+        "regl-scatter2d": "^3.2.3"
       }
     },
     "relateurl": {
@@ -42177,7 +45219,6 @@
       "version": "1.22.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
       "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
-      "dev": true,
       "requires": {
         "is-core-module": "^2.8.1",
         "path-parse": "^1.0.7",
@@ -42204,6 +45245,14 @@
       "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
       "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==",
       "peer": true
+    },
+    "resolve-protobuf-schema": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
+      "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
+      "requires": {
+        "protocol-buffers-schema": "^3.3.1"
+      }
     },
     "resolve-url": {
       "version": "0.2.1",
@@ -42409,6 +45458,11 @@
       "resolved": "https://registry.npmjs.org/rgba-regex/-/rgba-regex-1.0.0.tgz",
       "integrity": "sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=",
       "dev": true
+    },
+    "right-now": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/right-now/-/right-now-1.0.0.tgz",
+      "integrity": "sha512-DA8+YS+sMIVpbsuKgy+Z67L9Lxb1p05mNxRpDPNksPDEFir4vmBlUtuN9jkTGn9YMMdlBuK7XQgFiz6ws+yhSg=="
     },
     "rimraf": {
       "version": "3.0.2",
@@ -42975,11 +46029,15 @@
         "aproba": "^1.1.1"
       }
     },
+    "rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="
+    },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "safe-identifier": {
       "version": "0.4.2",
@@ -42999,8 +46057,7 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sane": {
       "version": "4.1.0",
@@ -43272,8 +46329,7 @@
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-      "dev": true
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "saxes": {
       "version": "5.0.1",
@@ -43509,6 +46565,11 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "shallow-copy": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz",
+      "integrity": "sha512-b6i4ZpVuUxB9h5gfCxPiusKYkqTMOjEbBs4wMaFbkfia4yFv92UKZ6Df8WXcKbn08JNL/abvg3FnMAOfakDvUw=="
+    },
     "shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -43553,6 +46614,11 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
+    },
+    "signum": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/signum/-/signum-1.0.0.tgz",
+      "integrity": "sha512-yodFGwcyt59XRh7w5W3jPcIQb3Bwi21suEfT7MAWnBX3iCdklJpgDgvGT9o04UonglZN5SNMfJFkHIR/jO8GHw=="
     },
     "simple-swizzle": {
       "version": "0.2.2",
@@ -43958,6 +47024,11 @@
       "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
       "dev": true
     },
+    "stack-trace": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
+      "integrity": "sha512-vjUc6sfgtgY0dxCdnc40mK6Oftjo9+2K8H/NG81TMhgL392FtiPA9tn9RLyTxXmTLPJPjF3VyzFp6bsWFLisMQ=="
+    },
     "stack-utils": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.5.tgz",
@@ -43980,6 +47051,74 @@
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.2.1.tgz",
       "integrity": "sha512-h88QkzREN/hy8eRdyNhhsO7RSJ5oyTqxxmmn0dzBIMUclZsjpfmrsg81vp8mjjAs2vAZ72nyWxRUwSwmh0e4xg==",
       "dev": true
+    },
+    "static-eval": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.1.0.tgz",
+      "integrity": "sha512-agtxZ/kWSsCkI5E4QifRwsaPs0P0JmZV6dkLz6ILYfFYQGn+5plctanRN+IC8dJRiFkyXHrwEE3W9Wmx67uDbw==",
+      "requires": {
+        "escodegen": "^1.11.1"
+      },
+      "dependencies": {
+        "escodegen": {
+          "version": "1.14.3",
+          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
+          "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
+          "requires": {
+            "esprima": "^4.0.1",
+            "estraverse": "^4.2.0",
+            "esutils": "^2.0.2",
+            "optionator": "^0.8.1",
+            "source-map": "~0.6.1"
+          }
+        },
+        "estraverse": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+          "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
+        },
+        "levn": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+          "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
+          "requires": {
+            "prelude-ls": "~1.1.2",
+            "type-check": "~0.3.2"
+          }
+        },
+        "optionator": {
+          "version": "0.8.3",
+          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+          "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+          "requires": {
+            "deep-is": "~0.1.3",
+            "fast-levenshtein": "~2.0.6",
+            "levn": "~0.3.0",
+            "prelude-ls": "~1.1.2",
+            "type-check": "~0.3.2",
+            "word-wrap": "~1.2.3"
+          }
+        },
+        "prelude-ls": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+          "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w=="
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "optional": true
+        },
+        "type-check": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+          "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
+          "requires": {
+            "prelude-ls": "~1.1.2"
+          }
+        }
+      }
     },
     "static-extend": {
       "version": "0.1.2",
@@ -44098,11 +47237,33 @@
         "xtend": "^4.0.0"
       }
     },
+    "stream-parser": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/stream-parser/-/stream-parser-0.3.1.tgz",
+      "integrity": "sha512-bJ/HgKq41nlKvlhccD5kaCr/P+Hu0wPNKPJOH7en+YrJu/9EgqUF+88w5Jb6KNcjOFMhfX4B2asfeAtIGuHObQ==",
+      "requires": {
+        "debug": "2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+        }
+      }
+    },
     "stream-shift": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
-      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
-      "dev": true
+      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
     },
     "strict-uri-encode": {
       "version": "1.1.0",
@@ -44148,6 +47309,23 @@
       "resolved": "https://registry.npmjs.org/string-natural-compare/-/string-natural-compare-3.0.1.tgz",
       "integrity": "sha512-n3sPwynL1nwKi3WJ6AIsClwBMa0zTi54fn2oLU6ndfTSIO05xaznjSf15PcBZU6FNWbmN5Q6cxT4V5hGvB4taw==",
       "dev": true
+    },
+    "string-split-by": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/string-split-by/-/string-split-by-1.0.0.tgz",
+      "integrity": "sha512-KaJKY+hfpzNyet/emP81PJA9hTVSfxNLS9SFTWxdCnnW1/zOOwiV248+EfoX7IQFcBaOp4G5YE6xTJMF+pLg6A==",
+      "requires": {
+        "parenthesis": "^3.1.5"
+      }
+    },
+    "string-to-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-to-arraybuffer/-/string-to-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-DaGZidzi93dwjQen5I2osxR9ERS/R7B1PFyufNMnzhj+fmlDQAc1DSDIJVJhgI8Oq221efIMbABUBdPHDRt43Q==",
+      "requires": {
+        "atob-lite": "^2.0.0",
+        "is-base64": "^0.1.0"
+      }
     },
     "string-width": {
       "version": "4.2.3",
@@ -44267,6 +47445,11 @@
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
     },
+    "strongly-connected-components": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strongly-connected-components/-/strongly-connected-components-1.0.1.tgz",
+      "integrity": "sha512-i0TFx4wPcO0FwX+4RkLJi1MxmcTv90jNZgxMu9XRnMXMeFUY1VJlIoXpZunPUvUUqbCT1pg5PEkFqqpcaElNaA=="
+    },
     "style-inject": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/style-inject/-/style-inject-0.3.0.tgz",
@@ -44356,6 +47539,19 @@
         }
       }
     },
+    "supercluster": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-7.1.5.tgz",
+      "integrity": "sha512-EulshI3pGUM66o6ZdH3ReiFcvHpM3vAigyK+vcxdjpJyEbIIrtbmBdY23mGgnI24uXiGFvrGq9Gkum/8U7vJWg==",
+      "requires": {
+        "kdbush": "^3.0.0"
+      }
+    },
+    "superscript-text": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/superscript-text/-/superscript-text-1.0.0.tgz",
+      "integrity": "sha512-gwu8l5MtRZ6koO0icVTlmN5pm7Dhh1+Xpe9O4x6ObMAsW+3jPbW14d1DsBq1F4wiI+WOFjXF35pslgec/G8yCQ=="
+    },
     "supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -44378,14 +47574,51 @@
     "supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
+    },
+    "svg-arc-to-cubic-bezier": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/svg-arc-to-cubic-bezier/-/svg-arc-to-cubic-bezier-3.2.0.tgz",
+      "integrity": "sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g=="
     },
     "svg-parser": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/svg-parser/-/svg-parser-2.0.4.tgz",
       "integrity": "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==",
       "dev": true
+    },
+    "svg-path-bounds": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/svg-path-bounds/-/svg-path-bounds-1.0.2.tgz",
+      "integrity": "sha512-H4/uAgLWrppIC0kHsb2/dWUYSmb4GE5UqH06uqWBcg6LBjX2fu0A8+JrO2/FJPZiSsNOKZAhyFFgsLTdYUvSqQ==",
+      "requires": {
+        "abs-svg-path": "^0.1.1",
+        "is-svg-path": "^1.0.1",
+        "normalize-svg-path": "^1.0.0",
+        "parse-svg-path": "^0.1.2"
+      },
+      "dependencies": {
+        "normalize-svg-path": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/normalize-svg-path/-/normalize-svg-path-1.1.0.tgz",
+          "integrity": "sha512-r9KHKG2UUeB5LoTouwDzBy2VxXlHsiM6fyLQvnJa0S5hrhzqElH/CH7TUGhT1fVvIYBIKf3OpY4YJ4CK+iaqHg==",
+          "requires": {
+            "svg-arc-to-cubic-bezier": "^3.0.0"
+          }
+        }
+      }
+    },
+    "svg-path-sdf": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/svg-path-sdf/-/svg-path-sdf-1.1.3.tgz",
+      "integrity": "sha512-vJJjVq/R5lSr2KLfVXVAStktfcfa1pNFjFOgyJnzZFXlO/fDZ5DmM8FpnSKKzLPfEYTVeXuVBTHF296TpxuJVg==",
+      "requires": {
+        "bitmap-sdf": "^1.0.0",
+        "draw-svg-path": "^1.0.0",
+        "is-svg-path": "^1.0.1",
+        "parse-svg-path": "^0.1.2",
+        "svg-path-bounds": "^1.0.1"
+      }
     },
     "svgo": {
       "version": "1.3.2",
@@ -44865,7 +48098,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
       "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-      "dev": true,
       "requires": {
         "readable-stream": "~2.3.6",
         "xtend": "~4.0.1"
@@ -44903,11 +48135,31 @@
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
     },
+    "tinycolor2": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.5.2.tgz",
+      "integrity": "sha512-h80m9GPFGbcLzZByXlNSEhp1gf8Dy+VX/2JCGUZsWLo7lV1mnE/XlxGYgRBoMLJh1lIDXP0EMC4RPTjlRaV+Bg=="
+    },
+    "tinyqueue": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
+      "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA=="
+    },
     "tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
       "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "dev": true
+    },
+    "to-array-buffer": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/to-array-buffer/-/to-array-buffer-3.2.0.tgz",
+      "integrity": "sha512-zN33mwi0gpL+7xW1ITLfJ48CEj6ZQW0ZAP0MU+2W3kEY0PAIncyuxmD4OqkUVhPAbTP7amq9j/iwvZKYS+lzSQ==",
+      "requires": {
+        "flatten-vertex-data": "^1.0.2",
+        "is-blob": "^2.0.1",
+        "string-to-arraybuffer": "^1.0.0"
+      }
     },
     "to-arraybuffer": {
       "version": "1.0.1",
@@ -44920,6 +48172,11 @@
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
       "dev": true
+    },
+    "to-float32": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/to-float32/-/to-float32-1.1.0.tgz",
+      "integrity": "sha512-keDnAusn/vc+R3iEiSDw8TOF7gPiTLdK1ArvWtYbJQiVfmRg6i/CAvbKq3uIS0vWroAC7ZecN3DjQKw3aSklUg=="
     },
     "to-object-path": {
       "version": "0.3.0",
@@ -44939,6 +48196,14 @@
             "is-buffer": "^1.1.5"
           }
         }
+      }
+    },
+    "to-px": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/to-px/-/to-px-1.0.1.tgz",
+      "integrity": "sha512-2y3LjBeIZYL19e5gczp14/uRWFDtDUErJPVN3VU9a7SJO+RjGRtYR47aMN2bZgGlxvW4ZcEz2ddUPVHXcMfuXw==",
+      "requires": {
+        "parse-unit": "^1.0.1"
       }
     },
     "to-regex": {
@@ -44973,11 +48238,38 @@
         "is-number": "^7.0.0"
       }
     },
+    "to-uint8": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/to-uint8/-/to-uint8-1.4.1.tgz",
+      "integrity": "sha512-o+ochsMlTZyucbww8It401FC2Rx+OP2RpDeYbA6h+y9HgedDl1UjdsJ9CmzKEG7AFP9es5PmJ4eDWeeeXihESg==",
+      "requires": {
+        "arr-flatten": "^1.1.0",
+        "clamp": "^1.0.1",
+        "is-base64": "^0.1.0",
+        "is-float-array": "^1.0.0",
+        "to-array-buffer": "^3.0.0"
+      }
+    },
     "toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "dev": true
+    },
+    "topojson-client": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.1.0.tgz",
+      "integrity": "sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==",
+      "requires": {
+        "commander": "2"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+        }
+      }
     },
     "tough-cookie": {
       "version": "4.0.0",
@@ -45089,8 +48381,7 @@
     "type": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
-      "dev": true
+      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
     },
     "type-check": {
       "version": "0.4.0",
@@ -45123,11 +48414,24 @@
         "mime-types": "~2.1.24"
       }
     },
+    "type-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/type-name/-/type-name-2.0.2.tgz",
+      "integrity": "sha512-kkgkuqR/jKdKO5oh/I2SMu2dGbLXoJq0zkdgbxaqYK+hr9S9edwVVGf+tMUFTx2gH9TN2+Zu9JZ/Njonb3cjhA=="
+    },
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-      "dev": true
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    },
+    "typedarray-pool": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/typedarray-pool/-/typedarray-pool-1.2.0.tgz",
+      "integrity": "sha512-YTSQbzX43yvtpfRtIDAYygoYtgT+Rpjuxy9iOpczrjpXLgGoyG7aS5USJXV2d3nn8uHTeb9rXDvzS27zUg5KYQ==",
+      "requires": {
+        "bit-twiddle": "^1.0.0",
+        "dup": "^1.0.0"
+      }
     },
     "typedarray-to-buffer": {
       "version": "3.1.5",
@@ -45258,8 +48562,7 @@
     "unquote": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
-      "integrity": "sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ=",
-      "dev": true
+      "integrity": "sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ="
     },
     "unset-value": {
       "version": "1.0.0",
@@ -45312,6 +48615,11 @@
       "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
       "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
       "dev": true
+    },
+    "update-diff": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/update-diff/-/update-diff-1.1.0.tgz",
+      "integrity": "sha512-rCiBPiHxZwT4+sBhEbChzpO5hYHjm91kScWgdHf4Qeafs6Ba7MBl+d9GlGv72bcTZQO0sLmtQS1pHSWoCLtN/A=="
     },
     "uri-js": {
       "version": "4.4.1",
@@ -45406,8 +48714,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "util.promisify": {
       "version": "1.0.0",
@@ -45425,11 +48732,54 @@
       "integrity": "sha1-ihagXURWV6Oupe7MWxKk+lN5dyw=",
       "dev": true
     },
+    "utils-copy": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/utils-copy/-/utils-copy-1.1.1.tgz",
+      "integrity": "sha512-+NhJVV+PcxjdpkMrVTqXhQHPldlFGca5XR9YnGyNn7kQ0fMi+DqNLzdnhJ4TJ1HNy/HzB7c+FPg3y+4icY99ZA==",
+      "requires": {
+        "const-pinf-float64": "^1.0.0",
+        "object-keys": "^1.0.9",
+        "type-name": "^2.0.0",
+        "utils-copy-error": "^1.0.0",
+        "utils-indexof": "^1.0.0",
+        "utils-regex-from-string": "^1.0.0",
+        "validate.io-array": "^1.0.3",
+        "validate.io-buffer": "^1.0.1",
+        "validate.io-nonnegative-integer": "^1.0.0"
+      }
+    },
+    "utils-copy-error": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-copy-error/-/utils-copy-error-1.0.1.tgz",
+      "integrity": "sha512-RbJcGPZ6Ru2HQk9SWkvbdWNPX58pt4MO5uXsOQRu4LEGWB3LglkRrmnE/Ph1qWg6ywQ0qj95wTz1OeqQ2l8DCA==",
+      "requires": {
+        "object-keys": "^1.0.9",
+        "utils-copy": "^1.1.0"
+      }
+    },
+    "utils-indexof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/utils-indexof/-/utils-indexof-1.0.0.tgz",
+      "integrity": "sha512-76QBfRJpn4A0P5uTO1x00x+Yog36w2Pab0n+aT9UfUvVa4l+e8k3p7YwNpDvfQ6+aKGZdxZpxcNotNS4YjFcyg==",
+      "requires": {
+        "validate.io-array-like": "^1.0.1",
+        "validate.io-integer-primitive": "^1.0.0"
+      }
+    },
     "utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
       "dev": true
+    },
+    "utils-regex-from-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/utils-regex-from-string/-/utils-regex-from-string-1.0.0.tgz",
+      "integrity": "sha512-xKfdmEF19iUu9TKxFiohQUlQTuqYdV80/CxHiudVI37iEV/OA4HHlXZoc4qvuO1B74EcBVpErBreRO/dpdLeYA==",
+      "requires": {
+        "regex-regex": "^1.0.0",
+        "validate.io-string-primitive": "^1.0.0"
+      }
     },
     "uuid": {
       "version": "8.3.2",
@@ -45472,6 +48822,82 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
+    "validate.io-array": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/validate.io-array/-/validate.io-array-1.0.6.tgz",
+      "integrity": "sha512-DeOy7CnPEziggrOO5CZhVKJw6S3Yi7e9e65R1Nl/RTN1vTQKnzjfvks0/8kQ40FP/dsjRAOd4hxmJ7uLa6vxkg=="
+    },
+    "validate.io-array-like": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/validate.io-array-like/-/validate.io-array-like-1.0.2.tgz",
+      "integrity": "sha512-rGLiN0cvY9OWzQcWP+RtqZR/MK9RUz3gKDTCcRLtEQ/BvlanMF5PyqtVIN+CgrIBCv/ypfme9v7r4yMJPYpbNA==",
+      "requires": {
+        "const-max-uint32": "^1.0.2",
+        "validate.io-integer-primitive": "^1.0.0"
+      }
+    },
+    "validate.io-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/validate.io-buffer/-/validate.io-buffer-1.0.2.tgz",
+      "integrity": "sha512-6Tad+/QYOxWEXsesKYak1mHOzGdPYS4QeHFImWn7ECi4GR0x3vh7+6+1yoLKNXiklKuTFOxHLG3kZy9tPX0GvQ=="
+    },
+    "validate.io-integer": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/validate.io-integer/-/validate.io-integer-1.0.5.tgz",
+      "integrity": "sha512-22izsYSLojN/P6bppBqhgUDjCkr5RY2jd+N2a3DCAUey8ydvrZ/OkGvFPR7qfOpwR2LC5p4Ngzxz36g5Vgr/hQ==",
+      "requires": {
+        "validate.io-number": "^1.0.3"
+      }
+    },
+    "validate.io-integer-primitive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/validate.io-integer-primitive/-/validate.io-integer-primitive-1.0.0.tgz",
+      "integrity": "sha512-4ARGKA4FImVWJgrgttLYsYJmDGwxlhLfDCdq09gyVgohLKKRUfD3VAo1L2vTRCLt6hDhDtFKdZiuYUTWyBggwg==",
+      "requires": {
+        "validate.io-number-primitive": "^1.0.0"
+      }
+    },
+    "validate.io-matrix-like": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/validate.io-matrix-like/-/validate.io-matrix-like-1.0.2.tgz",
+      "integrity": "sha512-86mqLUIkZCRAOVKZvpCB7sDCw1dKBjBkY+C6WO/wLo/jQx0sOqQZz3LLtDw0DCfuAKxRuhSmIpX3nzr0nWrbdw=="
+    },
+    "validate.io-ndarray-like": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/validate.io-ndarray-like/-/validate.io-ndarray-like-1.0.0.tgz",
+      "integrity": "sha512-OV85AosxraPFSXJwzv/d7Cu5/dLiyLtsHmxtHTJcHW1N0uscd0eJ2df1Zk+HdID0eUctUllW/1YuQPUJFv1pTA=="
+    },
+    "validate.io-nonnegative-integer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/validate.io-nonnegative-integer/-/validate.io-nonnegative-integer-1.0.0.tgz",
+      "integrity": "sha512-uOMekPwcl84yg8NR7zgIZCZ9pHCtd9CK1Ri51N+ZJLTe1HyLbmdFdy7ZmfkiHkMvB1pOxeQmd1/LBjKhUD1L3A==",
+      "requires": {
+        "validate.io-integer": "^1.0.5"
+      }
+    },
+    "validate.io-number": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/validate.io-number/-/validate.io-number-1.0.3.tgz",
+      "integrity": "sha512-kRAyotcbNaSYoDnXvb4MHg/0a1egJdLwS6oJ38TJY7aw9n93Fl/3blIXdyYvPOp55CNxywooG/3BcrwNrBpcSg=="
+    },
+    "validate.io-number-primitive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/validate.io-number-primitive/-/validate.io-number-primitive-1.0.0.tgz",
+      "integrity": "sha512-8rlCe7N0TRTd50dwk4WNoMXNbX/4+RdtqE3TO6Bk0GJvAgbQlfL5DGr/Pl9ZLbWR6CutMjE2cu+yOoCnFWk+Qw=="
+    },
+    "validate.io-positive-integer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/validate.io-positive-integer/-/validate.io-positive-integer-1.0.0.tgz",
+      "integrity": "sha512-eg4LSdyqjICNUZWRilcQ5l+YayRlu6yi+GQsWw1bCmtG9yayOPmLa1fPymEHPPhbvWPAv3w0LLbCsf03pBHZkg==",
+      "requires": {
+        "validate.io-integer": "^1.0.5"
+      }
+    },
+    "validate.io-string-primitive": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/validate.io-string-primitive/-/validate.io-string-primitive-1.0.1.tgz",
+      "integrity": "sha512-TORbkLMdOFkEbPtfdx76FSVQGSAzyUEMxI+pBq5pfFm1ZzIesP+XiGc6eIK75aKu7RA7a8EcqUv5OrY5wfog5w=="
+    },
     "value-equal": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
@@ -45495,6 +48921,16 @@
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
       "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
       "dev": true
+    },
+    "vt-pbf": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/vt-pbf/-/vt-pbf-3.1.3.tgz",
+      "integrity": "sha512-2LzDFzt0mZKZ9IpVF2r69G9bXaP2Q2sArJCmcCgvfTdCCZzSyz4aCLoQyUilu37Ll56tCblIZrXFIjNUpGIlmA==",
+      "requires": {
+        "@mapbox/point-geometry": "0.1.0",
+        "@mapbox/vector-tile": "^1.3.1",
+        "pbf": "^3.2.1"
+      }
     },
     "w3c-hr-time": {
       "version": "1.0.2",
@@ -45779,6 +49215,19 @@
       "dev": true,
       "requires": {
         "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "weak-map": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/weak-map/-/weak-map-1.0.8.tgz",
+      "integrity": "sha512-lNR9aAefbGPpHO7AEnY0hCFjz1eTkWCXYvkTRrTHs9qv8zJp+SkVYpzfLIFXQQiG3tVvbNFQgVg2bQS8YGgxyw=="
+    },
+    "webgl-context": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/webgl-context/-/webgl-context-2.2.0.tgz",
+      "integrity": "sha512-q/fGIivtqTT7PEoF07axFIlHNk/XCPaYpq64btnepopSWvKNFkoORlQYgqDigBIuGA1ExnFd/GnSUnBNEPQY7Q==",
+      "requires": {
+        "get-canvas-context": "^1.0.1"
       }
     },
     "webidl-conversions": {
@@ -46791,8 +50240,7 @@
     "word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-      "dev": true
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
     },
     "workbox-background-sync": {
       "version": "5.1.4",
@@ -47120,6 +50568,14 @@
         "microevent.ts": "~0.1.1"
       }
     },
+    "world-calendars": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/world-calendars/-/world-calendars-1.0.3.tgz",
+      "integrity": "sha512-sAjLZkBnsbHkHWVhrsCU5Sa/EVuf9QqgvrN8zyJ2L/F9FR9Oc6CvVK0674+PGAtmmmYQMH98tCUSO4QLQv3/TQ==",
+      "requires": {
+        "object-assign": "^4.1.0"
+      }
+    },
     "wrap-ansi": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
@@ -47134,8 +50590,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write-file-atomic": {
       "version": "3.0.3",
@@ -47180,8 +50635,7 @@
     "xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "dev": true
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "y18n": {
       "version": "4.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@testing-library/react": "^12.1.3",
         "@types/jest": "^27.4.0",
         "@types/node": "^17.0.18",
+        "@types/react-plotly.js": "^2.5.2",
         "@types/react-test-renderer": "^17.0.1",
         "base64-js": "^1.3.1",
         "clipboard-copy": "^4.0.1",
@@ -3849,6 +3850,12 @@
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
     },
+    "node_modules/@types/plotly.js": {
+      "version": "2.12.11",
+      "resolved": "https://registry.npmjs.org/@types/plotly.js/-/plotly.js-2.12.11.tgz",
+      "integrity": "sha512-FouDGLsFVFTBqedZSUK4LjPYm1HYRJeGfIideEhgsUu4htNmLGsVbbH7SUaCljYKbiZkeCCWinvVYJe8o3m6og==",
+      "dev": true
+    },
     "node_modules/@types/prettier": {
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.4.4.tgz",
@@ -3882,6 +3889,16 @@
       "integrity": "sha512-f96K3k+24RaLGVu/Y2Ng3e1EbZ8/cVJvypZWd7cy0ofCBaf2lcM46xNhycMZ2xGwbBjRql7hOlZ+e2WlJ5MH3Q==",
       "dev": true,
       "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-plotly.js": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@types/react-plotly.js/-/react-plotly.js-2.5.2.tgz",
+      "integrity": "sha512-hsCEdgGTEkeEXI8ZlB0qOgXCcDjq3NGsi/mlxOasAclScvk1i4b+ajaOj+J/j2Ay86I2a7eDxpuTHrBdVyUrkg==",
+      "dev": true,
+      "dependencies": {
+        "@types/plotly.js": "*",
         "@types/react": "*"
       }
     },
@@ -31185,6 +31202,12 @@
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
     },
+    "@types/plotly.js": {
+      "version": "2.12.11",
+      "resolved": "https://registry.npmjs.org/@types/plotly.js/-/plotly.js-2.12.11.tgz",
+      "integrity": "sha512-FouDGLsFVFTBqedZSUK4LjPYm1HYRJeGfIideEhgsUu4htNmLGsVbbH7SUaCljYKbiZkeCCWinvVYJe8o3m6og==",
+      "dev": true
+    },
     "@types/prettier": {
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.4.4.tgz",
@@ -31225,6 +31248,16 @@
       "integrity": "sha512-f96K3k+24RaLGVu/Y2Ng3e1EbZ8/cVJvypZWd7cy0ofCBaf2lcM46xNhycMZ2xGwbBjRql7hOlZ+e2WlJ5MH3Q==",
       "dev": true,
       "requires": {
+        "@types/react": "*"
+      }
+    },
+    "@types/react-plotly.js": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@types/react-plotly.js/-/react-plotly.js-2.5.2.tgz",
+      "integrity": "sha512-hsCEdgGTEkeEXI8ZlB0qOgXCcDjq3NGsi/mlxOasAclScvk1i4b+ajaOj+J/j2Ay86I2a7eDxpuTHrBdVyUrkg==",
+      "dev": true,
+      "requires": {
+        "@types/plotly.js": "*",
         "@types/react": "*"
       }
     },

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
   "dependencies": {
     "apollo-link-retry": "^2.2.16",
     "loglevel": "^1.8.0",
+    "plotly.js": "^2.17.1",
+    "react-plotly.js": "^2.6.0",
     "redux": "^4.1.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@testing-library/react": "^12.1.3",
     "@types/jest": "^27.4.0",
     "@types/node": "^17.0.18",
+    "@types/react-plotly.js": "^2.5.2",
     "@types/react-test-renderer": "^17.0.1",
     "base64-js": "^1.3.1",
     "clipboard-copy": "^4.0.1",

--- a/src/types/axes.test.ts
+++ b/src/types/axes.test.ts
@@ -6,6 +6,7 @@ describe("Axes", () => {
   it("creates the axes object", (): void => {
     const axesList: Axis[] = [
       {
+        index: 0,
         axisColor: new Color("rgb(256, 255, 254"),
         axisTitle: "X axis",
         showGrid: false,
@@ -18,6 +19,7 @@ describe("Axes", () => {
         minimum: 0
       },
       {
+        index: 1,
         axisColor: new Color("rgb(256, 255, 254"),
         axisTitle: "Y axis",
         showGrid: false,
@@ -34,6 +36,7 @@ describe("Axes", () => {
       count: 2,
       axisOptions: [
         {
+          index: 0,
           axisColor: new Color("rgb(256, 255, 254"),
           axisTitle: "X axis",
           showGrid: false,
@@ -46,6 +49,7 @@ describe("Axes", () => {
           minimum: 0
         },
         {
+          index: 1,
           axisColor: new Color("rgb(256, 255, 254"),
           axisTitle: "Y axis",
           showGrid: false,
@@ -62,6 +66,7 @@ describe("Axes", () => {
   it("throw error if count different to number of traces", (): void => {
     const axesList: Axis[] = [
       {
+        index: 0,
         axisColor: new Color("rgb(0, 0, 0"),
         axisTitle: "Z axis",
         showGrid: true,
@@ -86,8 +91,8 @@ describe("Axis", () => {
       [key: string]: any;
     };
     const baseObj: TempClass = {};
-    baseObj.index = 1;
     baseObj.autoScale = false;
+    baseObj.autoScaleThreshold = 0.7;
     baseObj.axisColor = new Color("rgb(255, 0, 0");
     baseObj.axisTitle = "Velocity";
     baseObj.showGrid = true;
@@ -102,12 +107,14 @@ describe("Axis", () => {
     baseObj.leftBottomSide = false;
     baseObj.maximum = 40;
     baseObj.minimum = 10;
+    baseObj.yAxis = true;
 
     // Construct trace from base object
-    const axis = Object.assign(new Axis(), baseObj);
+    const axis = Object.assign(new Axis(1), baseObj);
     expect(axis).toEqual({
       index: 1,
       autoScale: false,
+      autoScaleThreshold: 0.7,
       axisColor: new Color("rgb(255, 0, 0"),
       axisTitle: "Velocity",
       showGrid: true,
@@ -121,7 +128,8 @@ describe("Axis", () => {
       logScale: true,
       leftBottomSide: false,
       maximum: 40,
-      minimum: 10
+      minimum: 10,
+      yAxis: true
     });
     expect(axis).toBeInstanceOf(Axis);
   });
@@ -132,11 +140,12 @@ describe("Axis", () => {
     };
     const baseObj: TempClass = {};
     // Construct trace from base object
-    const axis = Object.assign(new Axis(), baseObj);
+    const axis = Object.assign(new Axis(0), baseObj);
 
     expect(axis).toEqual({
       index: 0,
       autoScale: true,
+      autoScaleThreshold: 0.95,
       axisColor: new Color("rgb(0, 0, 0"),
       axisTitle: "",
       showGrid: false,
@@ -150,7 +159,8 @@ describe("Axis", () => {
       logScale: false,
       leftBottomSide: true,
       maximum: 0,
-      minimum: 100
+      minimum: 100,
+      yAxis: false
     });
     expect(axis).toBeInstanceOf(Axis);
   });

--- a/src/types/axes.test.ts
+++ b/src/types/axes.test.ts
@@ -87,30 +87,25 @@ describe("Axes", () => {
 
 describe("Axis", () => {
   it("construct the axis with values", (): void => {
-    type TempClass = {
-      [key: string]: any;
-    };
-    const baseObj: TempClass = {};
-    baseObj.autoScale = false;
-    baseObj.autoScaleThreshold = 0.7;
-    baseObj.axisColor = new Color("rgb(255, 0, 0");
-    baseObj.axisTitle = "Velocity";
-    baseObj.showGrid = true;
-    baseObj.gridColor = new Color("rgb(255, 0, 0");
-    baseObj.dashGridLine = false;
-    baseObj.timeFormat = 2;
-    baseObj.scaleFormat = "0.0";
-    baseObj.scaleFont = new Font(10, FontStyle.Bold, "Comic sans");
-    baseObj.titleFont = new Font(10, FontStyle.Bold, "Comic sans");
-    baseObj.visible = false;
-    baseObj.logScale = true;
-    baseObj.leftBottomSide = false;
-    baseObj.maximum = 40;
-    baseObj.minimum = 10;
-    baseObj.yAxis = true;
+    const axis = new Axis(1);
+    axis.autoScale = false;
+    axis.autoScaleThreshold = 0.7;
+    axis.axisColor = new Color("rgb(255, 0, 0");
+    axis.axisTitle = "Velocity";
+    axis.showGrid = true;
+    axis.gridColor = new Color("rgb(255, 0, 0");
+    axis.dashGridLine = false;
+    axis.timeFormat = 2;
+    axis.scaleFormat = "0.0";
+    axis.scaleFont = new Font(10, FontStyle.Bold, "Comic sans");
+    axis.titleFont = new Font(10, FontStyle.Bold, "Comic sans");
+    axis.visible = false;
+    axis.logScale = true;
+    axis.leftBottomSide = false;
+    axis.maximum = 40;
+    axis.minimum = 10;
+    axis.yAxis = true;
 
-    // Construct trace from base object
-    const axis = Object.assign(new Axis(1), baseObj);
     expect(axis).toEqual({
       index: 1,
       autoScale: false,
@@ -135,12 +130,7 @@ describe("Axis", () => {
   });
 
   it("construct the axis with only defaults", (): void => {
-    type TempClass = {
-      [key: string]: any;
-    };
-    const baseObj: TempClass = {};
-    // Construct trace from base object
-    const axis = Object.assign(new Axis(0), baseObj);
+    const axis = new Axis(0);
 
     expect(axis).toEqual({
       index: 0,
@@ -158,8 +148,8 @@ describe("Axis", () => {
       visible: true,
       logScale: false,
       leftBottomSide: true,
-      maximum: 0,
-      minimum: 100,
+      maximum: 100,
+      minimum: 0,
       yAxis: false
     });
     expect(axis).toBeInstanceOf(Axis);

--- a/src/types/axes.test.ts
+++ b/src/types/axes.test.ts
@@ -1,0 +1,157 @@
+import { Color } from "./color";
+import { Axes, Axis } from "./axes";
+import { Font, FontStyle } from "./font";
+
+describe("Axes", () => {
+  it("creates the axes object", (): void => {
+    const axesList: Axis[] = [
+      {
+        axisColor: new Color("rgb(256, 255, 254"),
+        axisTitle: "X axis",
+        showGrid: false,
+        gridColor: new Color("rgb(256, 255, 254"),
+        dashGridLine: false,
+        titleFont: new Font(),
+        visible: true,
+        logScale: false,
+        maximum: 10,
+        minimum: 0
+      },
+      {
+        axisColor: new Color("rgb(256, 255, 254"),
+        axisTitle: "Y axis",
+        showGrid: false,
+        gridColor: new Color("rgb(256, 255, 254"),
+        titleFont: new Font(),
+        visible: true,
+        logScale: false,
+        maximum: 30,
+        minimum: 15
+      }
+    ];
+    const axes = new Axes(2, axesList);
+    expect(axes).toEqual({
+      count: 2,
+      axisOptions: [
+        {
+          axisColor: new Color("rgb(256, 255, 254"),
+          axisTitle: "X axis",
+          showGrid: false,
+          gridColor: new Color("rgb(256, 255, 254"),
+          dashGridLine: false,
+          titleFont: new Font(),
+          visible: true,
+          logScale: false,
+          maximum: 10,
+          minimum: 0
+        },
+        {
+          axisColor: new Color("rgb(256, 255, 254"),
+          axisTitle: "Y axis",
+          showGrid: false,
+          gridColor: new Color("rgb(256, 255, 254"),
+          titleFont: new Font(),
+          visible: true,
+          logScale: false,
+          maximum: 30,
+          minimum: 15
+        }
+      ]
+    });
+  });
+  it("throw error if count different to number of traces", (): void => {
+    const axesList: Axis[] = [
+      {
+        axisColor: new Color("rgb(0, 0, 0"),
+        axisTitle: "Z axis",
+        showGrid: true,
+        gridColor: new Color("rgb(0, 0, 0"),
+        dashGridLine: false,
+        titleFont: new Font(),
+        visible: true,
+        logScale: false,
+        maximum: 10,
+        minimum: 0
+      }
+    ];
+    expect(() => {
+      new Axes(3, axesList);
+    }).toThrow(Error("Count 3 is not equal to number of axes 1"));
+  });
+});
+
+describe("Axis", () => {
+  it("construct the axis with values", (): void => {
+    type TempClass = {
+      [key: string]: any;
+    };
+    const baseObj: TempClass = {};
+    baseObj.index = 1;
+    baseObj.autoScale = false;
+    baseObj.axisColor = new Color("rgb(255, 0, 0");
+    baseObj.axisTitle = "Velocity";
+    baseObj.showGrid = true;
+    baseObj.gridColor = new Color("rgb(255, 0, 0");
+    baseObj.dashGridLine = false;
+    baseObj.timeFormat = 2;
+    baseObj.scaleFormat = "0.0";
+    baseObj.scaleFont = new Font(10, FontStyle.Bold, "Comic sans");
+    baseObj.titleFont = new Font(10, FontStyle.Bold, "Comic sans");
+    baseObj.visible = false;
+    baseObj.logScale = true;
+    baseObj.leftBottomSide = false;
+    baseObj.maximum = 40;
+    baseObj.minimum = 10;
+
+    // Construct trace from base object
+    const axis = Object.assign(new Axis(), baseObj);
+    expect(axis).toEqual({
+      index: 1,
+      autoScale: false,
+      axisColor: new Color("rgb(255, 0, 0"),
+      axisTitle: "Velocity",
+      showGrid: true,
+      gridColor: new Color("rgb(255, 0, 0"),
+      dashGridLine: false,
+      timeFormat: 2,
+      scaleFormat: "0.0",
+      scaleFont: new Font(10, FontStyle.Bold, "Comic sans"),
+      titleFont: new Font(10, FontStyle.Bold, "Comic sans"),
+      visible: false,
+      logScale: true,
+      leftBottomSide: false,
+      maximum: 40,
+      minimum: 10
+    });
+    expect(axis).toBeInstanceOf(Axis);
+  });
+
+  it("construct the axis with only defaults", (): void => {
+    type TempClass = {
+      [key: string]: any;
+    };
+    const baseObj: TempClass = {};
+    // Construct trace from base object
+    const axis = Object.assign(new Axis(), baseObj);
+
+    expect(axis).toEqual({
+      index: 0,
+      autoScale: true,
+      axisColor: new Color("rgb(0, 0, 0"),
+      axisTitle: "",
+      showGrid: false,
+      gridColor: new Color("rgb(0, 0, 0"),
+      dashGridLine: true,
+      timeFormat: 0,
+      scaleFormat: "",
+      scaleFont: new Font(),
+      titleFont: new Font(10, FontStyle.Bold),
+      visible: true,
+      logScale: false,
+      leftBottomSide: true,
+      maximum: 0,
+      minimum: 100
+    });
+    expect(axis).toBeInstanceOf(Axis);
+  });
+});

--- a/src/types/axes.ts
+++ b/src/types/axes.ts
@@ -2,8 +2,9 @@ import { Color } from "./color";
 import { Font, FontStyle } from "./font";
 
 export class Axis {
-  public index?: number;
+  public index: number;
   public autoScale?: boolean;
+  public autoScaleThreshold?: number;
   public axisColor?: Color;
   public axisTitle?: string;
   public showGrid?: boolean;
@@ -18,15 +19,17 @@ export class Axis {
   public leftBottomSide?: boolean;
   public maximum?: number;
   public minimum?: number;
+  public yAxis?: boolean;
 
   /**
    * Set default values for properties not yet
    * set, otherwise use set property. Uses same
    * default values as csstudio.opibuilder.xygraph.
    */
-  public constructor() {
-    this.index = this.index ?? 0;
+  public constructor(idx: number) {
+    this.index = idx ?? 0;
     this.autoScale = this.autoScale ?? true;
+    this.autoScaleThreshold = this.autoScaleThreshold ?? 0.95;
     this.axisColor = this.axisColor ?? new Color("rgb(0, 0, 0");
     this.axisTitle = this.axisTitle ?? "";
     this.showGrid = this.showGrid ?? false;
@@ -41,6 +44,12 @@ export class Axis {
     this.leftBottomSide = this.leftBottomSide ?? true;
     this.maximum = this.maximum ?? 0;
     this.minimum = this.minimum ?? 100;
+    // If axis has index 1 or above, assume y axis
+    let axisBool = false;
+    if (this.index > 0) {
+      axisBool = true;
+    }
+    this.yAxis = this.yAxis ?? axisBool;
   }
 }
 

--- a/src/types/axes.ts
+++ b/src/types/axes.ts
@@ -27,29 +27,25 @@ export class Axis {
    * default values as csstudio.opibuilder.xygraph.
    */
   public constructor(idx: number) {
-    this.index = idx ?? 0;
-    this.autoScale = this.autoScale ?? true;
-    this.autoScaleThreshold = this.autoScaleThreshold ?? 0.95;
-    this.axisColor = this.axisColor ?? new Color("rgb(0, 0, 0");
-    this.axisTitle = this.axisTitle ?? "";
-    this.showGrid = this.showGrid ?? false;
-    this.gridColor = this.gridColor ?? new Color("rgb(0, 0, 0");
-    this.dashGridLine = this.dashGridLine ?? true;
-    this.timeFormat = this.timeFormat ?? 0;
-    this.scaleFormat = this.scaleFormat ?? "";
-    this.scaleFont = this.scaleFont ?? new Font();
-    this.titleFont = this.titleFont ?? new Font(10, FontStyle.Bold);
-    this.visible = this.visible ?? true;
-    this.logScale = this.logScale ?? false;
-    this.leftBottomSide = this.leftBottomSide ?? true;
-    this.maximum = this.maximum ?? 0;
-    this.minimum = this.minimum ?? 100;
+    this.index = idx;
+    this.autoScale = true;
+    this.autoScaleThreshold = 0.95;
+    this.axisColor = new Color("rgb(0, 0, 0");
+    this.axisTitle = "";
+    this.showGrid = false;
+    this.gridColor = new Color("rgb(0, 0, 0");
+    this.dashGridLine = true;
+    this.timeFormat = 0;
+    this.scaleFormat = "";
+    this.scaleFont = new Font();
+    this.titleFont = new Font(10, FontStyle.Bold);
+    this.visible = true;
+    this.logScale = false;
+    this.leftBottomSide = true;
+    this.minimum = 0;
+    this.maximum = 100;
     // If axis has index 1 or above, assume y axis
-    let axisBool = false;
-    if (this.index > 0) {
-      axisBool = true;
-    }
-    this.yAxis = this.yAxis ?? axisBool;
+    this.index > 0 ? (this.yAxis = true) : (this.yAxis = false);
   }
 }
 

--- a/src/types/axes.ts
+++ b/src/types/axes.ts
@@ -59,6 +59,11 @@ export class Axes {
         `Count ${count} is not equal to number of axes ${axes.length}`
       );
     }
+    if (count > 4) {
+      throw new Error(
+        `Number of axes ${count} is greater than maximum number 4.`
+      );
+    }
     this.count = count;
     this.axisOptions = axes;
   }

--- a/src/types/axes.ts
+++ b/src/types/axes.ts
@@ -1,0 +1,72 @@
+import { Color } from "./color";
+import { Font } from "./font";
+
+// TO DO - find out which variables always appear and which don't and add ?
+
+export class Axis {
+  public autoScale?: boolean;
+  public autoScaleThreshold?: number;
+  public autoScaleTight?: boolean;
+  public axisColor?: Color;
+  public axisTitle?: string;
+  public showGrid?: boolean;
+  public gridColor?: Color;
+  public dashGridLine?: boolean;
+  public timeFormat?: string;
+  public scaleFormat?: string;
+  public scaleFont?: Font;
+  public titleFont?: Font;
+  public visible?: boolean;
+  public logScale?: boolean;
+  public leftBottomSide?: boolean;
+  public maximum?: number;
+  public minimum?: number;
+
+  public constructor(
+    autoScale: boolean,
+    autoScaleThreshold: number,
+    autoScaleTight: boolean,
+    axisColor: Color,
+    axisTitle: string,
+    showGrid: boolean,
+    gridColor: Color,
+    dashGridLine: boolean,
+    timeFormat: string,
+    scaleFormat: string,
+    scaleFont: Font,
+    titleFont: Font,
+    visible: boolean,
+    logScale: boolean,
+    leftBottomSide: boolean,
+    maximum: number,
+    minimum: number
+  ) {
+    this.autoScale = autoScale;
+    this.autoScaleThreshold = autoScaleThreshold;
+    this.autoScaleTight = autoScaleTight;
+    this.axisColor = axisColor;
+    this.axisTitle = axisTitle;
+    this.showGrid = showGrid;
+    this.gridColor = gridColor;
+    this.dashGridLine = dashGridLine;
+    this.timeFormat = timeFormat;
+    this.scaleFormat = scaleFormat;
+    this.scaleFont = scaleFont;
+    this.titleFont = titleFont;
+    this.visible = visible;
+    this.logScale = logScale;
+    this.leftBottomSide = leftBottomSide;
+    this.maximum = maximum;
+    this.minimum = minimum;
+  }
+}
+
+export class Axes {
+  public count: number;
+  public axisOptions: Axis[];
+
+  public constructor(count: number, axes: Axis[]) {
+    this.count = count;
+    this.axisOptions = axes;
+  }
+}

--- a/src/types/axes.ts
+++ b/src/types/axes.ts
@@ -1,18 +1,15 @@
 import { Color } from "./color";
-import { Font } from "./font";
-
-// TO DO - find out which variables always appear and which don't and add ?
+import { Font, FontStyle } from "./font";
 
 export class Axis {
+  public index?: number;
   public autoScale?: boolean;
-  public autoScaleThreshold?: number;
-  public autoScaleTight?: boolean;
   public axisColor?: Color;
   public axisTitle?: string;
   public showGrid?: boolean;
   public gridColor?: Color;
   public dashGridLine?: boolean;
-  public timeFormat?: string;
+  public timeFormat?: number;
   public scaleFormat?: string;
   public scaleFont?: Font;
   public titleFont?: Font;
@@ -22,42 +19,28 @@ export class Axis {
   public maximum?: number;
   public minimum?: number;
 
-  public constructor(
-    autoScale: boolean,
-    autoScaleThreshold: number,
-    autoScaleTight: boolean,
-    axisColor: Color,
-    axisTitle: string,
-    showGrid: boolean,
-    gridColor: Color,
-    dashGridLine: boolean,
-    timeFormat: string,
-    scaleFormat: string,
-    scaleFont: Font,
-    titleFont: Font,
-    visible: boolean,
-    logScale: boolean,
-    leftBottomSide: boolean,
-    maximum: number,
-    minimum: number
-  ) {
-    this.autoScale = autoScale;
-    this.autoScaleThreshold = autoScaleThreshold;
-    this.autoScaleTight = autoScaleTight;
-    this.axisColor = axisColor;
-    this.axisTitle = axisTitle;
-    this.showGrid = showGrid;
-    this.gridColor = gridColor;
-    this.dashGridLine = dashGridLine;
-    this.timeFormat = timeFormat;
-    this.scaleFormat = scaleFormat;
-    this.scaleFont = scaleFont;
-    this.titleFont = titleFont;
-    this.visible = visible;
-    this.logScale = logScale;
-    this.leftBottomSide = leftBottomSide;
-    this.maximum = maximum;
-    this.minimum = minimum;
+  /**
+   * Set default values for properties not yet
+   * set, otherwise use set property. Uses same
+   * default values as csstudio.opibuilder.xygraph.
+   */
+  public constructor() {
+    this.index = this.index ?? 0;
+    this.autoScale = this.autoScale ?? true;
+    this.axisColor = this.axisColor ?? new Color("rgb(0, 0, 0");
+    this.axisTitle = this.axisTitle ?? "";
+    this.showGrid = this.showGrid ?? false;
+    this.gridColor = this.gridColor ?? new Color("rgb(0, 0, 0");
+    this.dashGridLine = this.dashGridLine ?? true;
+    this.timeFormat = this.timeFormat ?? 0;
+    this.scaleFormat = this.scaleFormat ?? "";
+    this.scaleFont = this.scaleFont ?? new Font();
+    this.titleFont = this.titleFont ?? new Font(10, FontStyle.Bold);
+    this.visible = this.visible ?? true;
+    this.logScale = this.logScale ?? false;
+    this.leftBottomSide = this.leftBottomSide ?? true;
+    this.maximum = this.maximum ?? 0;
+    this.minimum = this.minimum ?? 100;
   }
 }
 
@@ -66,6 +49,11 @@ export class Axes {
   public axisOptions: Axis[];
 
   public constructor(count: number, axes: Axis[]) {
+    if (count !== axes.length) {
+      throw new Error(
+        `Count ${count} is not equal to number of axes ${axes.length}`
+      );
+    }
     this.count = count;
     this.axisOptions = axes;
   }

--- a/src/types/props.ts
+++ b/src/types/props.ts
@@ -5,6 +5,8 @@ import { WidgetActions } from "../ui/widgets/widgetActions";
 import { Border } from "./border";
 import { Position } from "./position";
 import { PV } from "./pv";
+import { Traces } from "./traces";
+import { Axes } from "./axes";
 
 export type GenericProp =
   | string
@@ -18,7 +20,9 @@ export type GenericProp =
   | Rule[]
   | MacroMap
   | WidgetActions
-  | OpiFile;
+  | OpiFile
+  | Traces
+  | Axes;
 
 export interface Expression {
   boolExp: string;

--- a/src/types/traces.test.ts
+++ b/src/types/traces.test.ts
@@ -5,6 +5,7 @@ describe("Traces", () => {
   it("creates the traces object", (): void => {
     const traceList: Trace[] = [
       {
+        index: 0,
         name: "trace 1",
         plotMode: 1,
         lineWidth: 2,
@@ -16,6 +17,7 @@ describe("Traces", () => {
         visible: true
       },
       {
+        index: 1,
         name: "trace 2",
         plotMode: 1,
         lineWidth: 2,
@@ -33,6 +35,7 @@ describe("Traces", () => {
       pvName: "test",
       traceOptions: [
         {
+          index: 0,
           name: "trace 1",
           plotMode: 1,
           lineWidth: 2,
@@ -44,6 +47,7 @@ describe("Traces", () => {
           visible: true
         },
         {
+          index: 1,
           name: "trace 2",
           plotMode: 1,
           lineWidth: 2,
@@ -60,6 +64,7 @@ describe("Traces", () => {
   it("throw error if count different to number of traces", (): void => {
     const traceList: Trace[] = [
       {
+        index: 0,
         name: "trace 3",
         plotMode: 2,
         lineWidth: 3,
@@ -83,7 +88,6 @@ describe("Trace", () => {
       [key: string]: any;
     };
     const baseObj: TempClass = {};
-    baseObj.index = 0;
     baseObj.name = "trace 4";
     baseObj.plotMode = 2;
     baseObj.lineWidth = 5;
@@ -104,7 +108,7 @@ describe("Trace", () => {
     baseObj.yAxisIndex = 1;
 
     // Construct trace from base object
-    const trace = Object.assign(new Trace(), baseObj);
+    const trace = Object.assign(new Trace(0), baseObj);
 
     expect(trace).toEqual({
       index: 0,
@@ -136,7 +140,7 @@ describe("Trace", () => {
     };
     const baseObj: TempClass = {};
     // Construct trace from base object
-    const trace = Object.assign(new Trace(), baseObj);
+    const trace = Object.assign(new Trace(0), baseObj);
 
     expect(trace).toEqual({
       index: 0,
@@ -144,7 +148,7 @@ describe("Trace", () => {
       plotMode: 0,
       lineWidth: 1,
       traceType: 0,
-      traceColor: new Color("rgb(255, 255, 255"),
+      traceColor: new Color("rgb(21, 21, 196)"),
       updateDelay: 100,
       updateMode: 0,
       pointStyle: 0,

--- a/src/types/traces.test.ts
+++ b/src/types/traces.test.ts
@@ -84,31 +84,25 @@ describe("Traces", () => {
 
 describe("Trace", () => {
   it("construct the trace with values", (): void => {
-    type TempClass = {
-      [key: string]: any;
-    };
-    const baseObj: TempClass = {};
-    baseObj.name = "trace 4";
-    baseObj.plotMode = 2;
-    baseObj.lineWidth = 5;
-    baseObj.traceType = 1;
-    baseObj.traceColor = new Color("rgb(255, 254, 253");
-    baseObj.updateDelay = 50;
-    baseObj.updateMode = 3;
-    baseObj.pointStyle = 5;
-    baseObj.pointSize = 3;
-    baseObj.concatenateData = false;
-    baseObj.bufferSize = 1000;
-    baseObj.visible = true;
-    baseObj.xPv = "xPvTest";
-    baseObj.xPvValue = 5;
-    baseObj.xAxisIndex = 0;
-    baseObj.yPv = "yPvTest";
-    baseObj.yPvValue = 4;
-    baseObj.yAxisIndex = 1;
-
-    // Construct trace from base object
-    const trace = Object.assign(new Trace(0), baseObj);
+    const trace = new Trace(0);
+    trace.name = "trace 4";
+    trace.plotMode = 2;
+    trace.lineWidth = 5;
+    trace.traceType = 1;
+    trace.traceColor = new Color("rgb(255, 254, 253");
+    trace.updateDelay = 50;
+    trace.updateMode = 3;
+    trace.pointStyle = 5;
+    trace.pointSize = 3;
+    trace.concatenateData = false;
+    trace.bufferSize = 1000;
+    trace.visible = true;
+    trace.xPv = "xPvTest";
+    trace.xPvValue = 5;
+    trace.xAxisIndex = 0;
+    trace.yPv = "yPvTest";
+    trace.yPvValue = 4;
+    trace.yAxisIndex = 1;
 
     expect(trace).toEqual({
       index: 0,
@@ -135,12 +129,7 @@ describe("Trace", () => {
   });
 
   it("construct the trace with only defaults", (): void => {
-    type TempClass = {
-      [key: string]: any;
-    };
-    const baseObj: TempClass = {};
-    // Construct trace from base object
-    const trace = Object.assign(new Trace(0), baseObj);
+    const trace = new Trace(0);
 
     expect(trace).toEqual({
       index: 0,

--- a/src/types/traces.test.ts
+++ b/src/types/traces.test.ts
@@ -1,0 +1,164 @@
+import { Color } from "./color";
+import { Traces, Trace } from "./traces";
+
+describe("Traces", () => {
+  it("creates the traces object", (): void => {
+    const traceList: Trace[] = [
+      {
+        name: "trace 1",
+        plotMode: 1,
+        lineWidth: 2,
+        traceType: 2,
+        traceColor: new Color("rgba(255,0,0,255)"),
+        pointStyle: 1,
+        pointSize: 2,
+        concatenateData: false,
+        visible: true
+      },
+      {
+        name: "trace 2",
+        plotMode: 1,
+        lineWidth: 2,
+        traceType: 2,
+        traceColor: new Color("rgba(255,255,255)"),
+        pointStyle: 4,
+        pointSize: 2,
+        concatenateData: false,
+        visible: true
+      }
+    ];
+    const traces = new Traces(2, "test", traceList);
+    expect(traces).toEqual({
+      count: 2,
+      pvName: "test",
+      traceOptions: [
+        {
+          name: "trace 1",
+          plotMode: 1,
+          lineWidth: 2,
+          traceType: 2,
+          traceColor: new Color("rgba(255,0,0,255)"),
+          pointStyle: 1,
+          pointSize: 2,
+          concatenateData: false,
+          visible: true
+        },
+        {
+          name: "trace 2",
+          plotMode: 1,
+          lineWidth: 2,
+          traceType: 2,
+          traceColor: new Color("rgba(255,255,255)"),
+          pointStyle: 4,
+          pointSize: 2,
+          concatenateData: false,
+          visible: true
+        }
+      ]
+    });
+  });
+  it("throw error if count different to number of traces", (): void => {
+    const traceList: Trace[] = [
+      {
+        name: "trace 3",
+        plotMode: 2,
+        lineWidth: 3,
+        traceType: 2,
+        traceColor: new Color("rgba(255,0,0,255)"),
+        pointStyle: 1,
+        pointSize: 2,
+        concatenateData: true,
+        visible: true
+      }
+    ];
+    expect(() => {
+      new Traces(2, "test", traceList);
+    }).toThrow(Error("Count 2 is not equal to number of traces 1"));
+  });
+});
+
+describe("Trace", () => {
+  it("construct the trace with values", (): void => {
+    type TempClass = {
+      [key: string]: any;
+    };
+    const baseObj: TempClass = {};
+    baseObj.index = 0;
+    baseObj.name = "trace 4";
+    baseObj.plotMode = 2;
+    baseObj.lineWidth = 5;
+    baseObj.traceType = 1;
+    baseObj.traceColor = new Color("rgb(255, 254, 253");
+    baseObj.updateDelay = 50;
+    baseObj.updateMode = 3;
+    baseObj.pointStyle = 5;
+    baseObj.pointSize = 3;
+    baseObj.concatenateData = false;
+    baseObj.bufferSize = 1000;
+    baseObj.visible = true;
+    baseObj.xPv = "xPvTest";
+    baseObj.xPvValue = 5;
+    baseObj.xAxisIndex = 0;
+    baseObj.yPv = "yPvTest";
+    baseObj.yPvValue = 4;
+    baseObj.yAxisIndex = 1;
+
+    // Construct trace from base object
+    const trace = Object.assign(new Trace(), baseObj);
+
+    expect(trace).toEqual({
+      index: 0,
+      name: "trace 4",
+      plotMode: 2,
+      lineWidth: 5,
+      traceType: 1,
+      traceColor: new Color("rgb(255, 254, 253"),
+      updateDelay: 50,
+      updateMode: 3,
+      pointStyle: 5,
+      pointSize: 3,
+      concatenateData: false,
+      bufferSize: 1000,
+      visible: true,
+      xPv: "xPvTest",
+      xPvValue: 5,
+      xAxisIndex: 0,
+      yPv: "yPvTest",
+      yPvValue: 4,
+      yAxisIndex: 1
+    });
+    expect(trace).toBeInstanceOf(Trace);
+  });
+
+  it("construct the trace with only defaults", (): void => {
+    type TempClass = {
+      [key: string]: any;
+    };
+    const baseObj: TempClass = {};
+    // Construct trace from base object
+    const trace = Object.assign(new Trace(), baseObj);
+
+    expect(trace).toEqual({
+      index: 0,
+      name: "",
+      plotMode: 0,
+      lineWidth: 1,
+      traceType: 0,
+      traceColor: new Color("rgb(255, 255, 255"),
+      updateDelay: 100,
+      updateMode: 0,
+      pointStyle: 0,
+      pointSize: 4,
+      concatenateData: true,
+      bufferSize: 100,
+      visible: true,
+      xPv: undefined,
+      xPvValue: undefined,
+      xAxisIndex: 0,
+      yPv: undefined,
+      yPvValue: undefined,
+      yAxisIndex: 1
+    });
+    expect(trace).toBeInstanceOf(Trace);
+  });
+});

--- a/src/types/traces.ts
+++ b/src/types/traces.ts
@@ -54,21 +54,21 @@ export class Trace {
    * csstudio.opibuilder.xygraph.
    */
   public constructor(idx: number) {
-    this.index = idx ?? 0;
-    this.name = this.name ?? "";
-    this.plotMode = this.plotMode ?? 0;
-    this.lineWidth = this.lineWidth ?? 1;
-    this.traceType = this.traceType ?? 0;
-    this.traceColor = this.traceColor ?? TRACE_COLOR_ARRAY[this.index];
-    this.updateDelay = this.updateDelay ?? 100;
-    this.updateMode = this.updateMode ?? 0;
-    this.pointStyle = this.pointStyle ?? 0;
-    this.pointSize = this.pointSize ?? 4;
-    this.concatenateData = this.concatenateData ?? true;
-    this.bufferSize = this.bufferSize ?? 100;
-    this.visible = this.visible ?? true;
-    this.xAxisIndex = this.xAxisIndex ?? 0;
-    this.yAxisIndex = this.yAxisIndex ?? 1;
+    this.index = idx;
+    this.name = "";
+    this.plotMode = 0;
+    this.lineWidth = 1;
+    this.traceType = 0;
+    this.traceColor = TRACE_COLOR_ARRAY[this.index];
+    this.updateDelay = 100;
+    this.updateMode = 0;
+    this.pointStyle = 0;
+    this.pointSize = 4;
+    this.concatenateData = true;
+    this.bufferSize = 100;
+    this.visible = true;
+    this.xAxisIndex = 0;
+    this.yAxisIndex = 1;
   }
 }
 

--- a/src/types/traces.ts
+++ b/src/types/traces.ts
@@ -1,0 +1,77 @@
+import { Color } from "./color";
+
+// TO DO - find out which variables always appear and which don't and add ?
+
+export class Trace {
+  public name?: string;
+  public plotMode?: number; //convert to value instead of num?
+  public lineWidth?: number;
+  public traceType?: number; //convert?
+  public traceColor?: Color;
+  public updateDelay?: number;
+  public updateMode?: number; //convert
+  public pointStyle?: number; //convert
+  public pointSize?: number;
+  public concatenateData?: boolean;
+  public bufferSize?: number;
+  public visible?: boolean;
+  public antiAlias?: boolean;
+  public xPv?: string;
+  public xPvValue?: number;
+  public xAxisIndex?: number;
+  public yPv?: string;
+  public yPvValue?: number;
+  public yAxisIndex?: number;
+
+  public constructor(
+    name: string,
+    plotMode: number,
+    lineWidth: number,
+    traceType: number,
+    traceColor: Color,
+    updateDelay: number,
+    updateMode: number,
+    pointStyle: number,
+    pointSize: number,
+    concatenateData: boolean,
+    bufferSize: number,
+    visible: boolean,
+    antiAlias: boolean,
+    xPv: string,
+    xPvValue: number,
+    xAxisIndex: number,
+    yPv: string,
+    yPvValue: number,
+    yAxisIndex: number
+  ) {
+    this.name = name;
+    this.plotMode = plotMode;
+    this.lineWidth = lineWidth;
+    this.traceType = traceType;
+    this.traceColor = traceColor;
+    this.updateDelay = updateDelay;
+    this.updateMode = updateMode;
+    this.pointStyle = pointStyle;
+    this.pointSize = pointSize;
+    this.concatenateData = concatenateData;
+    this.bufferSize = bufferSize;
+    this.visible = visible;
+    this.antiAlias = antiAlias;
+    this.xPv = xPv;
+    this.xPvValue = xPvValue;
+    this.xAxisIndex = xAxisIndex;
+    this.yPv = yPv;
+    this.yPvValue = yPvValue;
+    this.yAxisIndex = yAxisIndex;
+  }
+}
+
+export class Traces {
+  public count: number;
+  public traceOptions: Trace[];
+
+  public constructor(count: number, traces: Trace[]) {
+    this.count = count;
+    this.traceOptions = traces;
+  }
+}

--- a/src/types/traces.ts
+++ b/src/types/traces.ts
@@ -1,68 +1,74 @@
 import { Color } from "./color";
 
-// TO DO - find out which variables always appear and which don't and add ?
+// Colour chart for traces
+
+const TRACE_COLOR_ARRAY: { [key: number]: Color } = {
+  0: new Color("rgb(21, 21, 196)"), // blue
+  1: new Color("rgb(242, 26, 26)"), // red
+  2: new Color("rgb(33, 179, 33)"), // green
+  3: new Color("rgb(0, 0, 0)"), // black
+  4: new Color("rgb(128, 0, 255)"), // violet
+  5: new Color("rgb(255, 170, 0)"), // (darkish) yellow
+  6: new Color("rgb(255, 0, 240)"), // pink
+  7: new Color("rgb(243, 132, 132)"), // peachy
+  8: new Color("rgb(0, 255, 11)"), // neon green
+  9: new Color("rgb(0, 214, 255)"), // neon blue
+  10: new Color("rgb(114, 40, 3)"), // brown
+  11: new Color("rgb(219, 128, 4)"), // orange
+  12: new Color("rgb(21, 21, 196)"), // Repeat colours until 20
+  13: new Color("rgb(242, 26, 26)"),
+  14: new Color("rgb(33, 179, 33)"),
+  15: new Color("rgb(0, 0, 0)"),
+  16: new Color("rgb(128, 0, 255)"),
+  17: new Color("rgb(255, 170, 0)"),
+  18: new Color("rgb(255, 0, 240)"),
+  19: new Color("rgb(243, 132, 132)")
+};
 
 export class Trace {
+  public index?: number;
   public name?: string;
-  public plotMode?: number; //convert to value instead of num?
+  public plotMode?: number;
   public lineWidth?: number;
-  public traceType?: number; //convert?
+  public traceType?: number;
   public traceColor?: Color;
   public updateDelay?: number;
-  public updateMode?: number; //convert
-  public pointStyle?: number; //convert
+  public updateMode?: number;
+  public pointStyle?: number;
   public pointSize?: number;
   public concatenateData?: boolean;
   public bufferSize?: number;
-  public visible?: boolean;
-  public antiAlias?: boolean;
-  public xPv?: string;
-  public xPvValue?: number;
+  public visible?: boolean = true;
+  public xPv?: string | null;
+  public xPvValue?: number | null;
   public xAxisIndex?: number;
-  public yPv?: string;
-  public yPvValue?: number;
+  public yPv?: string | null;
+  public yPvValue?: number | null;
   public yAxisIndex?: number;
 
-  public constructor(
-    name: string,
-    plotMode: number,
-    lineWidth: number,
-    traceType: number,
-    traceColor: Color,
-    updateDelay: number,
-    updateMode: number,
-    pointStyle: number,
-    pointSize: number,
-    concatenateData: boolean,
-    bufferSize: number,
-    visible: boolean,
-    antiAlias: boolean,
-    xPv: string,
-    xPvValue: number,
-    xAxisIndex: number,
-    yPv: string,
-    yPvValue: number,
-    yAxisIndex: number
-  ) {
-    this.name = name;
-    this.plotMode = plotMode;
-    this.lineWidth = lineWidth;
-    this.traceType = traceType;
-    this.traceColor = traceColor;
-    this.updateDelay = updateDelay;
-    this.updateMode = updateMode;
-    this.pointStyle = pointStyle;
-    this.pointSize = pointSize;
-    this.concatenateData = concatenateData;
-    this.bufferSize = bufferSize;
-    this.visible = visible;
-    this.antiAlias = antiAlias;
-    this.xPv = xPv;
-    this.xPvValue = xPvValue;
-    this.xAxisIndex = xAxisIndex;
-    this.yPv = yPv;
-    this.yPvValue = yPvValue;
-    this.yAxisIndex = yAxisIndex;
+  /**
+   * Constructs the trace and sets default values for
+   * properties, otherwise uses set property except for
+   * xPv, yPv, xPvValue and yPvValue as their defaults
+   * are undefined. Uses same default values as
+   * csstudio.opibuilder.xygraph.
+   */
+  public constructor() {
+    this.index = this.index ?? 0;
+    this.name = this.name ?? "";
+    this.plotMode = this.plotMode ?? 0;
+    this.lineWidth = this.lineWidth ?? 1;
+    this.traceType = this.traceType ?? 0;
+    this.traceColor = this.traceColor ?? TRACE_COLOR_ARRAY[this.index];
+    this.updateDelay = this.updateDelay ?? 100;
+    this.updateMode = this.updateMode ?? 0;
+    this.pointStyle = this.pointStyle ?? 0;
+    this.pointSize = this.pointSize ?? 4;
+    this.concatenateData = this.concatenateData ?? true;
+    this.bufferSize = this.bufferSize ?? 100;
+    this.visible = this.visible ?? true;
+    this.xAxisIndex = this.xAxisIndex ?? 0;
+    this.yAxisIndex = this.yAxisIndex ?? 1;
   }
 }
 
@@ -72,6 +78,11 @@ export class Traces {
   public traceOptions: Trace[];
 
   public constructor(count: number, pvName: string, traces: Trace[]) {
+    if (count !== traces.length) {
+      throw new Error(
+        `Count ${count} is not equal to number of traces ${traces.length}`
+      );
+    }
     this.count = count;
     this.pvName = pvName;
     this.traceOptions = traces;

--- a/src/types/traces.ts
+++ b/src/types/traces.ts
@@ -68,10 +68,12 @@ export class Trace {
 
 export class Traces {
   public count: number;
+  public pvName: string;
   public traceOptions: Trace[];
 
-  public constructor(count: number, traces: Trace[]) {
+  public constructor(count: number, pvName: string, traces: Trace[]) {
     this.count = count;
+    this.pvName = pvName;
     this.traceOptions = traces;
   }
 }

--- a/src/types/traces.ts
+++ b/src/types/traces.ts
@@ -26,7 +26,7 @@ const TRACE_COLOR_ARRAY: { [key: number]: Color } = {
 };
 
 export class Trace {
-  public index?: number;
+  public index: number;
   public name?: string;
   public plotMode?: number;
   public lineWidth?: number;
@@ -53,8 +53,8 @@ export class Trace {
    * are undefined. Uses same default values as
    * csstudio.opibuilder.xygraph.
    */
-  public constructor() {
-    this.index = this.index ?? 0;
+  public constructor(idx: number) {
+    this.index = idx ?? 0;
     this.name = this.name ?? "";
     this.plotMode = this.plotMode ?? 0;
     this.lineWidth = this.lineWidth ?? 1;

--- a/src/types/traces.ts
+++ b/src/types/traces.ts
@@ -14,15 +14,7 @@ const TRACE_COLOR_ARRAY: { [key: number]: Color } = {
   8: new Color("rgb(0, 255, 11)"), // neon green
   9: new Color("rgb(0, 214, 255)"), // neon blue
   10: new Color("rgb(114, 40, 3)"), // brown
-  11: new Color("rgb(219, 128, 4)"), // orange
-  12: new Color("rgb(21, 21, 196)"), // Repeat colours until 20
-  13: new Color("rgb(242, 26, 26)"),
-  14: new Color("rgb(33, 179, 33)"),
-  15: new Color("rgb(0, 0, 0)"),
-  16: new Color("rgb(128, 0, 255)"),
-  17: new Color("rgb(255, 170, 0)"),
-  18: new Color("rgb(255, 0, 240)"),
-  19: new Color("rgb(243, 132, 132)")
+  11: new Color("rgb(219, 128, 4)") // orange
 };
 
 export class Trace {
@@ -59,7 +51,9 @@ export class Trace {
     this.plotMode = 0;
     this.lineWidth = 1;
     this.traceType = 0;
-    this.traceColor = TRACE_COLOR_ARRAY[this.index];
+    // Repeat colours if enough traces
+    if (idx > 11) idx = idx - 11;
+    this.traceColor = TRACE_COLOR_ARRAY[idx];
     this.updateDelay = 100;
     this.updateMode = 0;
     this.pointStyle = 0;
@@ -81,6 +75,11 @@ export class Traces {
     if (count !== traces.length) {
       throw new Error(
         `Count ${count} is not equal to number of traces ${traces.length}`
+      );
+    }
+    if (count > 20) {
+      throw new Error(
+        `Number of traces ${count} is greater than maximum number 20.`
       );
     }
     this.count = count;

--- a/src/ui/widgets/EmbeddedDisplay/embeddedDisplay.tsx
+++ b/src/ui/widgets/EmbeddedDisplay/embeddedDisplay.tsx
@@ -23,6 +23,7 @@ import {
 import { GroupBoxComponent } from "../GroupBox/groupBox";
 import { useOpiFile } from "./useOpiFile";
 import { useId } from "react-id-generator";
+import { trimFromString } from "../utils";
 
 const EmbeddedDisplayProps = {
   ...WidgetPropType,
@@ -53,27 +54,25 @@ export const EmbeddedDisplay = (
 
   let scaleFactor = "1";
   if (description.autoZoomToFit) {
-    const heightString =
+    let heightString =
       typeof description.position.height === "undefined"
         ? "10"
         : description.position.height;
-    const widthString =
+    let widthString =
       typeof description.position.width === "undefined"
         ? "10"
         : description.position.width;
-    // Height and width property will take form "<num>px"
-    if (heightString.includes("px") && widthString.includes("px")) {
-      // Use the window size and display size to scale
-      const heightStrStripPx = heightString.slice(0, -2);
-      const scaleHeightVal = window.innerHeight / Number(heightStrStripPx);
-      const widthStrStripPx = widthString.slice(0, -2);
-      const scaleWidthVal = window.innerWidth / Number(widthStrStripPx);
-      const minScaleFactor = Math.min(scaleWidthVal, scaleHeightVal);
-      scaleFactor = String(minScaleFactor);
-      // Scale the flexcontainer height to fill window
-      if (window.innerHeight > Number(heightStrStripPx)) {
-        props.position.height = String(window.innerHeight) + "px";
-      }
+    // Height and width property will take form "<num>px" so trim
+    heightString = trimFromString(heightString);
+    widthString = trimFromString(widthString);
+    // Use the window size and display size to scale
+    const scaleHeightVal = window.innerHeight / heightString;
+    const scaleWidthVal = window.innerWidth / widthString;
+    const minScaleFactor = Math.min(scaleWidthVal, scaleHeightVal);
+    scaleFactor = String(minScaleFactor);
+    // Scale the flexcontainer height to fill window
+    if (window.innerHeight > heightString) {
+      props.position.height = String(window.innerHeight) + "px";
     }
   }
   let component: JSX.Element;

--- a/src/ui/widgets/EmbeddedDisplay/opiParser.test.ts
+++ b/src/ui/widgets/EmbeddedDisplay/opiParser.test.ts
@@ -282,4 +282,131 @@ describe("opi widget parser", (): void => {
     expect(widget.showUnits).toBeUndefined();
     log.setLevel("info");
   });
+  const xygraphString = `
+  <display typeId="org.csstudio.opibuilder.Display" version="1.0">
+  <x>87</x>
+  <y>387</y>
+  <width>456</width>
+  <height>473</height>
+  <font>
+    <fontdata fontName="helvetica" height="8" pixels="true" style="0" />
+  </font>
+  <foreground_color>
+    <color blue="0" green="0" name="Black" red="0" />
+  </foreground_color>
+  <background_color>
+    <color blue="200" green="200" name="Canvas" red="200" />
+  </background_color>
+  <show_grid>true</show_grid>
+  <widget typeId="org.csstudio.opibuilder.widgets.dawn.xygraph" version="1.0">
+    <axis_0_auto_scale>false</axis_0_auto_scale>
+    <axis_0_auto_scale_threshold>0.95</axis_0_auto_scale_threshold>
+    <axis_0_axis_color>
+      <color blue="0" green="0" name="Black" red="0" />
+    </axis_0_axis_color>
+    <axis_0_axis_title />
+    <axis_0_grid_color>
+      <color blue="0" green="0" name="Black" red="0" />
+    </axis_0_grid_color>
+    <axis_0_log_scale>false</axis_0_log_scale>
+    <axis_0_maximum>1024.0</axis_0_maximum>
+    <axis_0_minimum>-10.0</axis_0_minimum>
+    <axis_0_scale_font>
+      <fontdata fontName="helvetica" height="12" pixels="true" style="0" />
+    </axis_0_scale_font>
+    <axis_0_show_grid>false</axis_0_show_grid>
+    <axis_0_time_format>0</axis_0_time_format>
+    <axis_0_title_font>
+      <fontdata fontName="helvetica" height="12" pixels="true" style="0" />
+    </axis_0_title_font>
+    <axis_0_visible>true</axis_0_visible>
+    <axis_1_auto_scale>true</axis_1_auto_scale>
+    <axis_1_auto_scale_threshold>0.95</axis_1_auto_scale_threshold>
+    <axis_1_axis_color>
+      <color blue="0" green="0" name="Black" red="0" />
+    </axis_1_axis_color>
+    <axis_1_axis_title />
+    <axis_1_grid_color>
+      <color blue="0" green="0" name="Black" red="0" />
+    </axis_1_grid_color>
+    <axis_1_logScale>false</axis_1_logScale>
+    <axis_1_log_scale>false</axis_1_log_scale>
+    <axis_1_maximum>1.0</axis_1_maximum>
+    <axis_1_minimum>0.0</axis_1_minimum>
+    <axis_1_scale_font>
+      <fontdata fontName="helvetica" height="12" pixels="true" style="0" />
+    </axis_1_scale_font>
+    <axis_1_show_grid>false</axis_1_show_grid>
+    <axis_1_time_format>0</axis_1_time_format>
+    <axis_1_title_font>
+      <fontdata fontName="helvetica" height="12" pixels="true" style="0" />
+    </axis_1_title_font>
+    <axis_1_visible>true</axis_1_visible>
+    <axis_2_auto_scale>true</axis_2_auto_scale>
+    <axis_2_axis_color>
+      <color blue="0" green="0" name="Black" red="0" />
+    </axis_2_axis_color>
+    <axis_2_axis_title />
+    <axis_2_grid_color>
+      <color blue="0" green="0" name="Black" red="0" />
+    </axis_2_grid_color>
+    <axis_2_left_bottom_side>false</axis_2_left_bottom_side>
+    <axis_2_logScale>false</axis_2_logScale>
+    <axis_2_maximum>16600.0</axis_2_maximum>
+    <axis_2_minimum>8300.0</axis_2_minimum>
+    <axis_2_show_grid>false</axis_2_show_grid>
+    <axis_2_time_format>0</axis_2_time_format>
+    <axis_2_visible>false</axis_2_visible>
+    <axis_count>3</axis_count>
+    <background_color>
+      <color blue="200" green="200" name="Canvas" red="200" />
+    </background_color>
+    <border_alarm_sensitive>false</border_alarm_sensitive>
+    <border_style>0</border_style>
+    <border_width>0</border_width>
+    <font>
+      <fontdata fontName="helvetica" height="12" pixels="true" style="0" />
+    </font>
+    <foreground_color>
+      <color blue="0" green="0" name="Black" red="0" />
+    </foreground_color>
+    <height>200</height>
+    <name>EDM xyGraph</name>
+    <plot_area_background_color>
+      <color blue="200" green="200" name="Canvas" red="200" />
+    </plot_area_background_color>
+    <pv_name>$(trace_0_y_pv)</pv_name>
+    <show_legend>false</show_legend>
+    <show_plot_area_border>false</show_plot_area_border>
+    <show_toolbar>false</show_toolbar>
+    <title>Bunch motion standard deviation</title>
+    <title_font>
+      <fontdata fontName="helvetica" height="12" pixels="true" style="0" />
+    </title_font>
+    <tooltip>$(trace_0_y_pv)
+$(trace_0_y_pv_value)</tooltip>
+    <trace_0_anti_alias>false</trace_0_anti_alias>
+    <trace_0_buffer_size>65536</trace_0_buffer_size>
+    <trace_0_concatenate_data>false</trace_0_concatenate_data>
+    <trace_0_trace_color>
+      <color blue="192" green="0" name="blue-27" red="0" />
+    </trace_0_trace_color>
+    <trace_0_trace_type>0</trace_0_trace_type>
+    <trace_0_update_delay>0</trace_0_update_delay>
+    <trace_0_update_mode>3</trace_0_update_mode>
+    <trace_0_y_pv>$(device):$(adc_axis):ADC:MMS:STD</trace_0_y_pv>
+    <trace_count>1</trace_count>
+    <width>440</width>
+    <x>8</x>
+    <y>168</y>
+  </widget>
+  </display>`;
+  it("parses xygraph widget", (): void => {
+    const widget = parseOpi(xygraphString, "ca", PREFIX)
+      .children?.[0] as WidgetDescription;
+    expect(widget.traces.count).toEqual(1);
+    expect(widget.axes.count).toEqual(3);
+    expect(widget.traces.traceOptions[0].bufferSize).toEqual(65536);
+    expect(widget.axes.axisOptions[2].leftBottomSide).toEqual(false);
+  });
 });

--- a/src/ui/widgets/EmbeddedDisplay/opiParser.ts
+++ b/src/ui/widgets/EmbeddedDisplay/opiParser.ts
@@ -12,6 +12,8 @@ import {
   AbsolutePosition,
   RelativePosition
 } from "../../../types/position";
+import { Traces, Trace } from "../../../types/traces";
+import { Axes, Axis } from "../../../types/axes";
 import {
   ComplexParserDict,
   ParserDict,
@@ -63,7 +65,9 @@ const OPI_WIDGET_MAPPING: { [key: string]: any } = {
   "org.csstudio.opibuilder.widgets.LED": "led",
   "org.csstudio.opibuilder.widgets.Image": "image",
   "org.csstudio.opibuilder.widgets.edm.symbolwidget": "pngsymbol",
-  "org.csstudio.opibuilder.widgets.detailpanel": "device"
+  "org.csstudio.opibuilder.widgets.detailpanel": "device",
+  "org.csstudio.opibuilder.widgets.dawn.xygraph": "xyplot",
+  "org.csstudio.opibuilder.widgets.xyGraph": "xyplot"
 };
 
 /**
@@ -455,6 +459,128 @@ function opiParseLabelPosition(props: any): string {
 }
 
 /**
+ * Parses a props object into an AllTraces object that
+ * contains an array of Trace objects
+ * @param props
+ * @returns allTraces
+ */
+function opiParseTraces(props: any): Traces {
+  const count = opiParseNumber(props.trace_count);
+  const traces: Trace[] = [];
+  for (let i = 0; i < count; i++) {
+    const _trace = parseMultipleNamedProps("trace", props, i);
+    traces.push(_trace);
+  }
+  return new Traces(count, traces);
+}
+
+/**
+ * Parses a props object into an AllAxes object that
+ * contains an array of Axis objects
+ * @param props
+ * @returns allAxes
+ */
+function opiParseAxes(props: any): Axes {
+  const count = opiParseNumber(props.axis_count);
+  const axes: Axis[] = [];
+  for (let i = 0; i < count; i++) {
+    const _axis = parseMultipleNamedProps("axis", props, i);
+    axes.push(_axis);
+  }
+  return new Axes(count, axes);
+}
+
+/**
+ * Converts property name from snake case to camel
+ * case. This is needed to dynamically sort through
+ * all of each traces properties, although it's a
+ * bit messy and clunky.
+ */
+function parseName(propName: string) {
+  const propStringArray = propName.split("_").slice(2);
+  let newName = propStringArray.shift();
+  propStringArray.forEach((word: string) => {
+    newName += word.charAt(0).toUpperCase() + word.slice(1);
+  });
+  return newName;
+}
+
+/**
+ * Not sure what to call this function, but
+ * it iterates over and parses props that have
+ * format {name}_{number}_{actual prop name}. Returns
+ * an array of these props
+ */
+function parseMultipleNamedProps(name: string, props: any, idx: number) {
+  const COLOR_PROPS = ["traceColor", "axisColor", "gridColor"];
+  const FONT_PROPS = ["scaleFont", "titleFont"];
+  const STRING_PROPS = [
+    "name",
+    "xPv",
+    "yPv",
+    "axisTitle",
+    "timeFormat",
+    "scaleFormat"
+  ];
+  const BOOL_PROPS = [
+    "antiAlias",
+    "concatenateData",
+    "visible",
+    "autoScale",
+    "autoScaleTight",
+    "showGrid",
+    "dashGridLine",
+    "logScale",
+    "leftBottomSide"
+  ];
+  const NUM_PROPS = [
+    "updateDelay",
+    "updateMode",
+    "bufferSize",
+    "plotMode",
+    "lineWidth",
+    "pointSize",
+    "pointStyle",
+    "traceType",
+    "xPvValue",
+    "yPvValue",
+    "xAxisIndex",
+    "yAxisIndex",
+    "maximum",
+    "minimum",
+    "autoScaleThreshold"
+  ];
+  type TempClass = {
+    [key: string]: string | boolean | number | Color | Font;
+  };
+  const _obj: TempClass = {};
+  const num = `${name}_${idx}_`;
+  const names = Object.getOwnPropertyNames(props);
+  const newProps = names.filter(s => s.includes(num));
+  newProps.forEach(item => {
+    const newName = parseName(item);
+    try {
+      if (newName) {
+        if (BOOL_PROPS.includes(newName)) {
+          _obj[newName] = opiParseBoolean(props[item]);
+        } else if (NUM_PROPS.includes(newName)) {
+          _obj[newName] = opiParseNumber(props[item]);
+        } else if (COLOR_PROPS.includes(newName)) {
+          _obj[newName] = opiParseColor(props[item]);
+        } else if (STRING_PROPS.includes(newName)) {
+          _obj[newName] = opiParseString(props[item]);
+        } else if (FONT_PROPS.includes(newName)) {
+          _obj[newName] = opiParseFont(props[item]);
+        }
+      }
+    } catch {
+      // do nothing
+    }
+  });
+  return _obj;
+}
+
+/**
  * Attempt to return the widget associated with a props object, failing
  * that will return a shape object
  * @param props
@@ -516,7 +642,13 @@ export const OPI_SIMPLE_PARSERS: ParserDict = {
   actionsFromPv: ["actions_from_pv", opiParseBoolean],
   itemsFromPv: ["items_from_pv", opiParseBoolean],
   deviceName: ["device_name", opiParseString],
-  autoZoomToFit: ["auto_zoom_to_fit_all", opiParseBoolean]
+  autoZoomToFit: ["auto_zoom_to_fit_all", opiParseBoolean],
+  plotBackgroundColor: ["plot_area_background_color", opiParseColor], //these are all plot props
+  title: ["title", opiParseString],
+  titleFont: ["title_font", opiParseFont],
+  showLegend: ["show_legend", opiParseBoolean],
+  showPlotBorder: ["show_plot_area_border", opiParseBoolean],
+  showToolbar: ["show_toolbar", opiParseBoolean]
 };
 
 /**
@@ -529,7 +661,9 @@ export const OPI_COMPLEX_PARSERS: ComplexParserDict = {
   position: opiParsePosition,
   border: opiParseBorder,
   file: opiParseFile,
-  alarmSensitive: opiParseAlarmSensitive
+  alarmSensitive: opiParseAlarmSensitive,
+  traces: opiParseTraces,
+  axes: opiParseAxes
 };
 
 function opiPatchRules(widgetDescription: WidgetDescription): void {

--- a/src/ui/widgets/EmbeddedDisplay/opiParser.ts
+++ b/src/ui/widgets/EmbeddedDisplay/opiParser.ts
@@ -459,30 +459,37 @@ function opiParseLabelPosition(props: any): string {
 }
 
 /**
- * Parses a props object into an AllTraces object that
+ * Parses a props object into an Traces object that
  * contains an array of Trace objects
- * @param props
- * @returns allTraces
+ * @param props list of props for this element
+ * @returns a Traces object
  */
 function opiParseTraces(props: any): Traces {
+  // Find PV value if it's one of the trace properties
+  let pvName = opiParseString(props.pv_name);
+  if (pvName.includes("trace_")) {
+    pvName = opiParseString(props[pvName.slice(2, -1)]);
+  }
   const count = opiParseNumber(props.trace_count);
   const traces: Trace[] = [];
+  // Parse all of the 'trace' properties
   for (let i = 0; i < count; i++) {
     const _trace = parseMultipleNamedProps("trace", props, i);
     traces.push(_trace);
   }
-  return new Traces(count, traces);
+  return new Traces(count, pvName, traces);
 }
 
 /**
  * Parses a props object into an AllAxes object that
  * contains an array of Axis objects
  * @param props
- * @returns allAxes
+ * @returns an Axes object.
  */
 function opiParseAxes(props: any): Axes {
   const count = opiParseNumber(props.axis_count);
   const axes: Axis[] = [];
+  // Parse all of the 'axis' properties
   for (let i = 0; i < count; i++) {
     const _axis = parseMultipleNamedProps("axis", props, i);
     axes.push(_axis);
@@ -495,10 +502,15 @@ function opiParseAxes(props: any): Axes {
  * case. This is needed to dynamically sort through
  * all of each traces properties, although it's a
  * bit messy and clunky.
+ * @param propName string to convert
+ * @returns newly formatted string
  */
-function parseName(propName: string) {
+function snakeCaseToCamelCase(propName: string) {
+  // Split string by underscore
   const propStringArray = propName.split("_").slice(2);
+  // Remove first element, this shouldn't be uppercase
   let newName = propStringArray.shift();
+  // Loop over and capitalise first character of each string
   propStringArray.forEach((word: string) => {
     newName += word.charAt(0).toUpperCase() + word.slice(1);
   });
@@ -506,12 +518,16 @@ function parseName(propName: string) {
 }
 
 /**
- * Not sure what to call this function, but
- * it iterates over and parses props that have
+ * Iterate over and parse props that have
  * format {name}_{number}_{actual prop name}. Returns
- * an array of these props
+ * an array of these props.
+ * @param name string to search for in prop names
+ * @param props props to parse
+ * @param idx number to search for in prop names
+ * @returns object containing parsed props
  */
 function parseMultipleNamedProps(name: string, props: any, idx: number) {
+  // TO DO - this feels clunky, better way to do it?
   const COLOR_PROPS = ["traceColor", "axisColor", "gridColor"];
   const FONT_PROPS = ["scaleFont", "titleFont"];
   const STRING_PROPS = [
@@ -550,15 +566,18 @@ function parseMultipleNamedProps(name: string, props: any, idx: number) {
     "minimum",
     "autoScaleThreshold"
   ];
+  // Need to specify this so we can assign values
   type TempClass = {
     [key: string]: string | boolean | number | Color | Font;
   };
   const _obj: TempClass = {};
+  // Create keyword string and search for matches
   const num = `${name}_${idx}_`;
   const names = Object.getOwnPropertyNames(props);
   const newProps = names.filter(s => s.includes(num));
   newProps.forEach(item => {
-    const newName = parseName(item);
+    // For each match, convert the name and parse
+    const newName = snakeCaseToCamelCase(item);
     try {
       if (newName) {
         if (BOOL_PROPS.includes(newName)) {

--- a/src/ui/widgets/EmbeddedDisplay/opiParser.ts
+++ b/src/ui/widgets/EmbeddedDisplay/opiParser.ts
@@ -474,8 +474,9 @@ function opiParseTraces(props: any): Traces {
   const traces: Trace[] = [];
   // Parse all of the 'trace' properties
   for (let i = 0; i < count; i++) {
-    const _trace = parseMultipleNamedProps("trace", props, i);
-    traces.push(_trace);
+    const _obj = parseMultipleNamedProps("trace", props, i);
+    const trace = Object.assign(new Trace(), _obj);
+    traces.push(trace);
   }
   return new Traces(count, pvName, traces);
 }
@@ -491,8 +492,9 @@ function opiParseAxes(props: any): Axes {
   const axes: Axis[] = [];
   // Parse all of the 'axis' properties
   for (let i = 0; i < count; i++) {
-    const _axis = parseMultipleNamedProps("axis", props, i);
-    axes.push(_axis);
+    const _obj = parseMultipleNamedProps("axis", props, i);
+    const axis = Object.assign(new Axis(), _obj);
+    axes.push(axis);
   }
   return new Axes(count, axes);
 }
@@ -539,11 +541,9 @@ function parseMultipleNamedProps(name: string, props: any, idx: number) {
     "scaleFormat"
   ];
   const BOOL_PROPS = [
-    "antiAlias",
     "concatenateData",
     "visible",
     "autoScale",
-    "autoScaleTight",
     "showGrid",
     "dashGridLine",
     "logScale",
@@ -563,14 +563,15 @@ function parseMultipleNamedProps(name: string, props: any, idx: number) {
     "xAxisIndex",
     "yAxisIndex",
     "maximum",
-    "minimum",
-    "autoScaleThreshold"
+    "minimum"
   ];
   // Need to specify this so we can assign values
   type TempClass = {
     [key: string]: string | boolean | number | Color | Font;
   };
   const _obj: TempClass = {};
+  // Set the trace index
+  _obj.index = idx;
   // Create keyword string and search for matches
   const num = `${name}_${idx}_`;
   const names = Object.getOwnPropertyNames(props);

--- a/src/ui/widgets/EmbeddedDisplay/opiParser.ts
+++ b/src/ui/widgets/EmbeddedDisplay/opiParser.ts
@@ -474,8 +474,7 @@ function opiParseTraces(props: any): Traces {
   const traces: Trace[] = [];
   // Parse all of the 'trace' properties
   for (let i = 0; i < count; i++) {
-    const _obj = parseMultipleNamedProps("trace", props, i);
-    const trace = Object.assign(new Trace(i), _obj);
+    const trace = parseMultipleNamedProps("trace", props, new Trace(i));
     traces.push(trace);
   }
   return new Traces(count, pvName, traces);
@@ -492,8 +491,7 @@ function opiParseAxes(props: any): Axes {
   const axes: Axis[] = [];
   // Parse all of the 'axis' properties
   for (let i = 0; i < count; i++) {
-    const _obj = parseMultipleNamedProps("axis", props, i);
-    const axis = Object.assign(new Axis(i), _obj);
+    const axis = parseMultipleNamedProps("axis", props, new Axis(i));
     axes.push(axis);
   }
   return new Axes(count, axes);
@@ -528,7 +526,7 @@ function snakeCaseToCamelCase(propName: string) {
  * @param idx number to search for in prop names
  * @returns object containing parsed props
  */
-function parseMultipleNamedProps(name: string, props: any, idx: number) {
+function parseMultipleNamedProps(name: string, props: any, obj: any) {
   // TO DO - this feels clunky, better way to do it?
   const COLOR_PROPS = ["traceColor", "axisColor", "gridColor"];
   const FONT_PROPS = ["scaleFont", "titleFont"];
@@ -570,9 +568,9 @@ function parseMultipleNamedProps(name: string, props: any, idx: number) {
   type TempClass = {
     [key: string]: string | boolean | number | Color | Font;
   };
-  const _obj: TempClass = {};
+  const parsedProps: TempClass = {};
   // Create keyword string and search for matches
-  const num = `${name}_${idx}_`;
+  const num = `${name}_${obj.index}_`;
   const names = Object.getOwnPropertyNames(props);
   const newProps = names.filter(s => s.includes(num));
   newProps.forEach(item => {
@@ -581,22 +579,23 @@ function parseMultipleNamedProps(name: string, props: any, idx: number) {
     try {
       if (newName) {
         if (BOOL_PROPS.includes(newName)) {
-          _obj[newName] = opiParseBoolean(props[item]);
+          parsedProps[newName] = opiParseBoolean(props[item]);
         } else if (NUM_PROPS.includes(newName)) {
-          _obj[newName] = opiParseNumber(props[item]);
+          parsedProps[newName] = opiParseNumber(props[item]);
         } else if (COLOR_PROPS.includes(newName)) {
-          _obj[newName] = opiParseColor(props[item]);
+          parsedProps[newName] = opiParseColor(props[item]);
         } else if (STRING_PROPS.includes(newName)) {
-          _obj[newName] = opiParseString(props[item]);
+          parsedProps[newName] = opiParseString(props[item]);
         } else if (FONT_PROPS.includes(newName)) {
-          _obj[newName] = opiParseFont(props[item]);
+          parsedProps[newName] = opiParseFont(props[item]);
         }
       }
     } catch {
       // do nothing
     }
   });
-  return _obj;
+  // Return instance of trace/axis with parsed props in it
+  return Object.assign(obj, parsedProps);
 }
 
 /**

--- a/src/ui/widgets/EmbeddedDisplay/opiParser.ts
+++ b/src/ui/widgets/EmbeddedDisplay/opiParser.ts
@@ -514,7 +514,7 @@ function parseMultipleNamedProps(name: string, props: any, obj: any) {
   const newProps = names.filter(s => s.includes(num));
   newProps.forEach(item => {
     // For each match, convert the name and parse
-    const newName = snakeCaseToCamelCase(item);
+    const newName = snakeCaseToCamelCase(item, num.length, undefined);
     try {
       if (newName) {
         // Get the type of the property
@@ -532,7 +532,9 @@ function parseMultipleNamedProps(name: string, props: any, obj: any) {
         }
       }
     } catch {
-      // do nothing
+      // Sometimes properties exist but are empty e.g. <axis_0_axis_title />
+      // and trying to parse this throws an exception. We want to catch and ignore
+      // this, and not include the empty property in our new obj.
     }
   });
   // Return instance of trace/axis with parsed props in it

--- a/src/ui/widgets/EmbeddedDisplay/opiParser.ts
+++ b/src/ui/widgets/EmbeddedDisplay/opiParser.ts
@@ -475,7 +475,7 @@ function opiParseTraces(props: any): Traces {
   // Parse all of the 'trace' properties
   for (let i = 0; i < count; i++) {
     const _obj = parseMultipleNamedProps("trace", props, i);
-    const trace = Object.assign(new Trace(), _obj);
+    const trace = Object.assign(new Trace(i), _obj);
     traces.push(trace);
   }
   return new Traces(count, pvName, traces);
@@ -493,7 +493,7 @@ function opiParseAxes(props: any): Axes {
   // Parse all of the 'axis' properties
   for (let i = 0; i < count; i++) {
     const _obj = parseMultipleNamedProps("axis", props, i);
-    const axis = Object.assign(new Axis(), _obj);
+    const axis = Object.assign(new Axis(i), _obj);
     axes.push(axis);
   }
   return new Axes(count, axes);
@@ -547,7 +547,8 @@ function parseMultipleNamedProps(name: string, props: any, idx: number) {
     "showGrid",
     "dashGridLine",
     "logScale",
-    "leftBottomSide"
+    "leftBottomSide",
+    "yAxis"
   ];
   const NUM_PROPS = [
     "updateDelay",
@@ -570,8 +571,6 @@ function parseMultipleNamedProps(name: string, props: any, idx: number) {
     [key: string]: string | boolean | number | Color | Font;
   };
   const _obj: TempClass = {};
-  // Set the trace index
-  _obj.index = idx;
   // Create keyword string and search for matches
   const num = `${name}_${idx}_`;
   const names = Object.getOwnPropertyNames(props);

--- a/src/ui/widgets/EmbeddedDisplay/parser.ts
+++ b/src/ui/widgets/EmbeddedDisplay/parser.ts
@@ -95,9 +95,10 @@ export function genericParser(
       newProps[prop] = widget[prop];
     }
   }
-  // For XYPlot, pv name can be a trace value that we found and
-  // set as a property on our new trace prop, so set this here
-  // TO DO - find a better way of doing this?
+  // TO DO - a way of parsing nested macros for PVs needs to be properly implemented.
+  // Currently nested macros are not parsed, which means a PV connection cannot be made.
+  // This is a hack to get it to work for XYPlot, but this will fail for multiple PVs
+  // on a single widget, and is not an ideal way of implementing.
   if (newProps.hasOwnProperty("traces")) {
     newProps.pvName.name = newProps.traces.pvName;
   }

--- a/src/ui/widgets/EmbeddedDisplay/parser.ts
+++ b/src/ui/widgets/EmbeddedDisplay/parser.ts
@@ -95,6 +95,12 @@ export function genericParser(
       newProps[prop] = widget[prop];
     }
   }
+  // For XYPlot, pv name can be a trace value that we found and
+  // set as a property on our new trace prop, so set this here
+  // TO DO - find a better way of doing this?
+  if (newProps.hasOwnProperty("traces")) {
+    newProps.pvName.name = newProps.traces.pvName;
+  }
 
   return newProps;
 }

--- a/src/ui/widgets/XYPlot/xyPlot.tsx
+++ b/src/ui/widgets/XYPlot/xyPlot.tsx
@@ -1,0 +1,147 @@
+import React, { CSSProperties } from "react";
+import { Widget } from "../widget";
+import {
+  InferWidgetProps,
+  ColorPropOpt,
+  StringPropOpt,
+  FontPropOpt,
+  TracesPropOpt,
+  AxesPropOpt,
+  BoolPropOpt,
+  FloatPropOpt
+} from "../propTypes";
+import { Axes } from "../../../types/axes";
+import { PVComponent, PVWidgetPropType } from "../widgetProps";
+import { registerWidget } from "../register";
+import Plot from "react-plotly.js";
+
+export const XYPlotProps = {
+  height: FloatPropOpt,
+  width: FloatPropOpt,
+  plotBackgroundColor: ColorPropOpt,
+  title: StringPropOpt,
+  titleFont: FontPropOpt,
+  showLegend: BoolPropOpt,
+  showPlotBorder: BoolPropOpt,
+  showToolbar: BoolPropOpt,
+  traces: TracesPropOpt,
+  axes: AxesPropOpt
+};
+
+export type XYPlotComponentProps = InferWidgetProps<typeof XYPlotProps> &
+  PVComponent;
+
+export const XYPlotComponent = (props: XYPlotComponentProps): JSX.Element => {
+  const {
+    height,
+    width,
+    value,
+    plotBackgroundColor,
+    title,
+    titleFont,
+    showLegend,
+    showPlotBorder,
+    showToolbar,
+    traces,
+    axes
+  } = props;
+  const font = titleFont?.css();
+  let fontSize = 10;
+  if (typeof font?.fontSize === "string") {
+    // weird stuff to convert it back to number we need
+    fontSize = parseFloat(font.fontSize.slice(0, -3)) * 10;
+  } else if (font?.fontSize) {
+    fontSize = font?.fontSize;
+  }
+  // fontsize could be string or number
+
+  const fakeData: any[] = [
+    {
+      name: "dataset1",
+      x: [0, 1, 2, 3, 4, 5],
+      y: [10, 15, 17, 19, 25],
+      type: "scatter",
+      mode: "lines",
+      marker: {
+        color: "red",
+        symbol: "circle"
+      }
+    }
+  ];
+  if (axes && traces && titleFont && plotBackgroundColor) {
+    return (
+      <Plot
+        data={fakeData}
+        layout={{
+          margin: {
+            t: 20,
+            b: 5
+          },
+          paper_bgcolor: plotBackgroundColor.toString(),
+          plot_bgcolor: plotBackgroundColor.toString(),
+          showlegend: showLegend,
+          width: width,
+          height: height,
+          title: {
+            text: `<b>${title}</b>`,
+            font: {
+              family: font?.fontFamily,
+              size: fontSize
+            }
+          },
+          xaxis: {
+            showline: true,
+            visible: true,
+            showgrid: axes.axisOptions[0].showGrid,
+            gridwidth: 0.5,
+            gridcolor: axes.axisOptions[0].axisColor?.toString(),
+            tickcolor: axes.axisOptions[0].axisColor?.toString(),
+            zeroline: false,
+            automargin: true,
+            title: {
+              text: axes.axisOptions[0].axisTitle
+                ? axes.axisOptions[0].axisTitle
+                : "X",
+              standoff: 0
+            },
+            titlefont: {
+              family: font?.fontFamily,
+              size: fontSize
+            }
+          },
+          yaxis: {
+            showline: true,
+            showgrid: axes.axisOptions[1].showGrid,
+            gridwidth: 0.5,
+            gridcolor: axes.axisOptions[0].axisColor?.toString(),
+            tickcolor: axes.axisOptions[0].axisColor?.toString(),
+            zeroline: false,
+            automargin: true,
+            title: {
+              text: axes.axisOptions[0].axisTitle
+                ? axes.axisOptions[0].axisTitle
+                : "Y",
+              standoff: 0
+            },
+            titlefont: {
+              family: font?.fontFamily,
+              size: fontSize
+            }
+          }
+        }}
+      />
+    );
+  }
+  return <></>;
+};
+
+const XYPlotWidgetProps = {
+  ...XYPlotProps,
+  ...PVWidgetPropType
+};
+
+export const XYPlot = (
+  props: InferWidgetProps<typeof XYPlotWidgetProps>
+): JSX.Element => <Widget baseWidget={XYPlotComponent} {...props} />;
+
+registerWidget(XYPlot, XYPlotWidgetProps, "xyplot");

--- a/src/ui/widgets/XYPlot/xyPlot.tsx
+++ b/src/ui/widgets/XYPlot/xyPlot.tsx
@@ -20,6 +20,7 @@ import {
   NewAxisSettings
 } from "./xyPlotOptions";
 import { Color } from "../../../types/color";
+import { trimFromString } from "../utils";
 
 export const XYPlotProps = {
   height: FloatPropOpt,
@@ -69,11 +70,9 @@ export const XYPlotComponent = (props: XYPlotComponentProps): JSX.Element => {
       style = { border: "1px solid black", padding: "1px" };
     }
     const font = titleFont?.css();
-    // Sometimes font is a string with "px" on the end....
-    if (typeof font?.fontSize === "string") {
-      // Convert string to number
-      font.fontSize = parseFloat(font.fontSize.slice(0, -3)) * 10;
-    }
+    // Sometimes font is a string with "px" on the end
+    if (typeof font.fontSize === "string")
+      font.fontSize = trimFromString(font.fontSize);
 
     const newAxisOptions = createAxes(axes.axisOptions, font);
     newAxisOptions.forEach((newAxis: NewAxisSettings, index: number) => {
@@ -114,7 +113,22 @@ export const XYPlotComponent = (props: XYPlotComponentProps): JSX.Element => {
       </div>
     );
   }
-  return <></>;
+  // If doesn't pass checks above, render empty box with msg
+  return (
+    <div
+      style={{
+        width: `${width}px`,
+        height: `${height}px`,
+        fontSize: "14px",
+        fontWeight: "bold",
+        border: "2px solid red",
+        padding: "1px"
+      }}
+    >
+      XYPlot could not be displayed. Please check the .opi file and connection
+      to PV {traces?.pvName}.
+    </div>
+  );
 };
 
 const XYPlotWidgetProps = {

--- a/src/ui/widgets/XYPlot/xyPlotOptions.test.ts
+++ b/src/ui/widgets/XYPlot/xyPlotOptions.test.ts
@@ -3,12 +3,8 @@ import { Color } from "../../../types/color";
 import { DType } from "../../../types/dtypes";
 import { Font, FontStyle } from "../../../types/font";
 import { Traces } from "../../../types/traces";
-import {
-  calculateAxisLimits,
-  createAxes,
-  createTraces,
-  roundValue
-} from "./xyPlotOptions";
+import { roundValue } from "../utils";
+import { calculateAxisLimits, createAxes, createTraces } from "./xyPlotOptions";
 
 const DATA = [0, 3, 4, 8];
 const ARRAY_DATA = new DType({

--- a/src/ui/widgets/XYPlot/xyPlotOptions.test.ts
+++ b/src/ui/widgets/XYPlot/xyPlotOptions.test.ts
@@ -269,7 +269,7 @@ describe("Create trace options object", (): void => {
         },
         mode: "markers",
         type: "scatter",
-        x: [1, 2, 3],
+        x: [0, 1, 2],
         y: [3, 4, 8]
       }
     ]);

--- a/src/ui/widgets/XYPlot/xyPlotOptions.test.ts
+++ b/src/ui/widgets/XYPlot/xyPlotOptions.test.ts
@@ -330,7 +330,8 @@ describe("Create axis options object", (): void => {
         dashGridLine: false,
         axisColor: new Color("rgb(255, 255, 255"),
         minimum: 1,
-        maximum: 10
+        maximum: 10,
+        scaleFormat: "0.0"
       }
     ];
     const font = new Font(10, FontStyle.Regular, "sans");
@@ -349,7 +350,8 @@ describe("Create axis options object", (): void => {
         showline: true,
         tickcolor: "rgb(255, 255, 255",
         visible: true,
-        zeroline: false
+        zeroline: false,
+        tickformat: "0.0"
       }
     ]);
   });
@@ -364,7 +366,8 @@ describe("Create axis options object", (): void => {
         dashGridLine: false,
         axisColor: new Color("rgb(255, 255, 255"),
         minimum: 1,
-        maximum: 10
+        maximum: 10,
+        scaleFormat: "0.00"
       }
     ];
     const font = new Font(10, FontStyle.Regular, "sans");
@@ -382,6 +385,7 @@ describe("Create axis options object", (): void => {
         showgrid: true,
         showline: true,
         tickcolor: "rgb(255, 255, 255",
+        tickformat: "0.00",
         title: {
           standoff: 0,
           text: "Test Plot"
@@ -398,21 +402,26 @@ describe("Create axis options object", (): void => {
 
   test("Shift axis if additional y axis", (): void => {
     const axis = {
-      index: 0,
+      index: 1,
       axisTitle: "Test Plot",
       visible: true,
       showGrid: true,
       dashGridLine: false,
       axisColor: new Color("rgb(255, 255, 255"),
       minimum: 1,
-      maximum: 10
+      maximum: 10,
+      leftBottomSide: true,
+      yAxis: false,
+      scaleFormat: ""
     };
     const axis1 = { ...axis };
     axis1.index = 1;
     axis1.minimum = -5;
+    axis1.yAxis = true;
     const axis2 = { ...axis };
     axis2.index = 2;
     axis2.maximum = 50;
+    axis2.yAxis = true;
     const axes: Axis[] = [axis, axis1, axis2];
     const font = new Font(10, FontStyle.Regular, "sans");
     const axisOptions = createAxes(axes, font.css());
@@ -433,6 +442,63 @@ describe("Create axis options object", (): void => {
       showline: true,
       side: "left",
       tickcolor: "rgb(255, 255, 255",
+      tickformat: "",
+      title: {
+        standoff: 0,
+        text: "Test Plot"
+      },
+      titlefont: {
+        family: "sans,sans-serif",
+        size: "1rem"
+      },
+      visible: true,
+      zeroline: false
+    });
+  });
+
+  test("Don't shift axis if additional x axis on opposite side", (): void => {
+    const axis = {
+      index: 0,
+      axisTitle: "Test Plot",
+      visible: true,
+      showGrid: true,
+      dashGridLine: false,
+      axisColor: new Color("rgb(255, 255, 255"),
+      minimum: 1,
+      maximum: 10,
+      yAxis: false,
+      leftBottomSide: true,
+      scaleFormat: ""
+    };
+    const axis1 = { ...axis };
+    axis1.index = 1;
+    axis1.minimum = -5;
+    axis1.yAxis = true;
+    const axis2 = { ...axis };
+    axis2.index = 2;
+    axis2.leftBottomSide = false;
+    axis2.maximum = 50;
+    const axes: Axis[] = [axis, axis1, axis2];
+    const font = new Font(10, FontStyle.Regular, "sans");
+    const axisOptions = createAxes(axes, font.css());
+
+    // Check that third axis has shifted
+    expect(axisOptions[2]).toEqual({
+      anchor: "free",
+      automargin: true,
+      autorange: false,
+      gridcolor: "rgb(255, 255, 255",
+      griddash: false,
+      gridwidth: 0.5,
+      minor: { ticks: "outside" },
+      overlaying: "x",
+      position: 0,
+      range: [1, 50],
+      showgrid: true,
+      showline: true,
+      side: "right",
+      tickcolor: "rgb(255, 255, 255",
+      tickformat: "",
       title: {
         standoff: 0,
         text: "Test Plot"

--- a/src/ui/widgets/XYPlot/xyPlotOptions.test.ts
+++ b/src/ui/widgets/XYPlot/xyPlotOptions.test.ts
@@ -1,0 +1,448 @@
+import { Axis } from "../../../types/axes";
+import { Color } from "../../../types/color";
+import { DType } from "../../../types/dtypes";
+import { Font, FontStyle } from "../../../types/font";
+import { Traces } from "../../../types/traces";
+import {
+  calculateAxisLimits,
+  createAxes,
+  createTraces,
+  roundValue
+} from "./xyPlotOptions";
+
+const DATA = [0, 3, 4, 8];
+const ARRAY_DATA = new DType({
+  arrayValue: new Float32Array(DATA)
+});
+
+describe("round values", (): void => {
+  test("returns zero if values zero", (): void => {
+    const rounded = roundValue(0, 0);
+
+    expect(rounded).toEqual(0);
+  });
+
+  test("rounds down if roundType 0", (): void => {
+    const rounded = roundValue(7.5, 0);
+
+    expect(rounded).toBeLessThan(7.5);
+  });
+
+  test("rounds up if roundType 1", (): void => {
+    const rounded = roundValue(7.5, 1);
+
+    expect(rounded).toBeGreaterThan(7.5);
+  });
+
+  test("rounds to first significant figure", (): void => {
+    const rounded1Sf = roundValue(64, 1);
+    const rounded2Sf = roundValue(5.6, 1);
+    const rounded3Sf = roundValue(3.789, 1);
+    const rounded4Sf = roundValue(0.23, 1);
+    const rounded5Sf = roundValue(0.045, 1);
+    const rounded6Sf = roundValue(0.0084, 1);
+    const rounded7Sf = roundValue(-0.00021, 0);
+
+    expect(rounded1Sf).toEqual(70);
+    expect(rounded2Sf).toEqual(6);
+    expect(rounded3Sf).toEqual(4);
+    expect(rounded4Sf).toEqual(0.3);
+    expect(rounded5Sf).toEqual(0.05);
+    expect(rounded6Sf).toEqual(0.009);
+    expect(rounded7Sf).toEqual(-0.0003);
+  });
+});
+
+describe("calculate axis limits", (): void => {
+  test("Use set limits if autoscale false", (): void => {
+    // here i need to create a new axis options with range
+    // and an old axis options with the properties i need
+    const oldAxisOpts: any = { autoScale: false };
+    let newAxisOpts: any = { range: [1, 10] };
+    const data: any[] = [{ x: [0, 3, 4] }, { x: [5, 4, 1] }];
+    newAxisOpts = calculateAxisLimits(oldAxisOpts, newAxisOpts, data);
+
+    expect(newAxisOpts.range).toEqual([1, 10]);
+  });
+
+  test("Use set limits if autoscale threshold not exceeded", (): void => {
+    const oldAxisOpts: any = { autoScale: true, autoScaleThreshold: 0.99 };
+    let newAxisOpts: any = { range: [1, 10] };
+    const data: any[] = [{ x: [0, 3, 4] }, { x: [5, 4, 1] }];
+    newAxisOpts = calculateAxisLimits(oldAxisOpts, newAxisOpts, data);
+
+    expect(newAxisOpts.range).toEqual([1, 10]);
+  });
+
+  test("Use autoscale if autoscale threshold exceeded", (): void => {
+    const oldAxisOpts: any = { autoScale: true, autoScaleThreshold: 0.01 };
+    let newAxisOpts: any = { range: [1, 10] };
+    const data: any[] = [{ x: [0, 3, 4] }, { x: [5, 4, 1] }];
+    newAxisOpts = calculateAxisLimits(oldAxisOpts, newAxisOpts, data);
+
+    expect(newAxisOpts.range).toEqual([0, 5]);
+  });
+
+  test("Set axis limits for x", (): void => {
+    const oldAxisOpts: any = {
+      autoScale: true,
+      autoScaleThreshold: 0.95,
+      yAxis: false,
+      index: 0
+    };
+    let newAxisOpts: any = { range: [1, 10] };
+    const data: any[] = [
+      { x: [0, 3, 4], y: [11, 32, 40.3] },
+      { x: [5, 4, 1], y: [16, 29.5, 45] }
+    ];
+    newAxisOpts = calculateAxisLimits(oldAxisOpts, newAxisOpts, data);
+
+    expect(newAxisOpts.range).toEqual([1, 10]);
+  });
+
+  test("Set axis limits for y", (): void => {
+    const oldAxisOpts: any = {
+      autoScale: true,
+      autoScaleThreshold: 0.95,
+      yAxis: true,
+      index: 1
+    };
+    let newAxisOpts: any = { range: [1, 100] };
+    const data: any[] = [
+      { x: [0, 3, 4], y: [11, 32, 40.3] },
+      { x: [5, 4, 1], y: [16, 29.5, 45] }
+    ];
+    newAxisOpts = calculateAxisLimits(oldAxisOpts, newAxisOpts, data);
+
+    expect(newAxisOpts.range).toEqual([1, 100]);
+  });
+});
+
+describe("Create trace options object", (): void => {
+  test("Return empty array if no data", (): void => {
+    const traces: Traces = { count: 0, pvName: "test", traceOptions: [] };
+    const val = new DType({ stringValue: "3.141", arrayValue: undefined });
+    const bytesPerElement = 4;
+    const traceOptions = createTraces(traces, val, bytesPerElement);
+
+    expect(traceOptions).toEqual([]);
+  });
+
+  test("Create bar chart trace", (): void => {
+    const traces: Traces = {
+      count: 1,
+      pvName: "test",
+      traceOptions: [
+        {
+          index: 0,
+          traceColor: new Color("rgb(255, 0, 0)"),
+          pointStyle: 0,
+          pointSize: 2,
+          traceType: 3
+        }
+      ]
+    };
+    const bytesPerElement = 4;
+    const traceOptions = createTraces(traces, ARRAY_DATA, bytesPerElement);
+
+    expect(traceOptions).toEqual([
+      {
+        marker: {
+          color: "rgb(255, 0, 0)",
+          size: 2,
+          symbol: "none"
+        },
+        type: "bar",
+        x: [0, 1, 2, 3],
+        y: [0, 3, 4, 8]
+      }
+    ]);
+  });
+
+  test("Create line plot trace", (): void => {
+    const traces: Traces = {
+      count: 1,
+      pvName: "test",
+      traceOptions: [
+        {
+          index: 0,
+          traceColor: new Color("rgb(250, 0, 0)"),
+          lineWidth: 2,
+          pointStyle: 3,
+          pointSize: 6,
+          traceType: 2
+        }
+      ]
+    };
+    const bytesPerElement = 4;
+    const traceOptions = createTraces(traces, ARRAY_DATA, bytesPerElement);
+
+    expect(traceOptions).toEqual([
+      {
+        line: {
+          color: "rgb(250, 0, 0)",
+          width: 2
+        },
+        marker: {
+          color: "rgb(250, 0, 0)",
+          size: 6,
+          symbol: "triangle-up"
+        },
+        mode: "markers",
+        type: "scatter",
+        x: [0, 1, 2, 3],
+        y: [0, 3, 4, 8]
+      }
+    ]);
+  });
+
+  test("Create area plot trace", (): void => {
+    const traces: Traces = {
+      count: 1,
+      pvName: "test",
+      traceOptions: [
+        {
+          index: 0,
+          traceColor: new Color("rgb(250, 0, 0)"),
+          lineWidth: 2,
+          pointStyle: 6,
+          pointSize: 6,
+          traceType: 4
+        }
+      ]
+    };
+    const bytesPerElement = 4;
+    const traceOptions = createTraces(traces, ARRAY_DATA, bytesPerElement);
+
+    expect(traceOptions).toEqual([
+      {
+        line: {
+          color: "rgb(250, 0, 0)",
+          width: 2
+        },
+        marker: {
+          color: "rgb(250, 0, 0)",
+          size: 6,
+          symbol: "diamond-open"
+        },
+        fill: "tonexty",
+        fillcolor: "rgb(250, 0, 0)",
+        mode: "lines",
+        type: "scatter",
+        x: [0, 1, 2, 3],
+        y: [0, 3, 4, 8]
+      }
+    ]);
+  });
+
+  /*
+  test("Concatenate new data onto old", (): void => {
+    // TO DO - when concatenation works, add test
+  });*/
+
+  test("Cut data down to buffer size, last n points", (): void => {
+    const traces: Traces = {
+      count: 1,
+      pvName: "test",
+      traceOptions: [
+        {
+          index: 0,
+          traceColor: new Color("rgb(250, 0, 0)"),
+          lineWidth: 2,
+          pointStyle: 3,
+          pointSize: 6,
+          traceType: 2,
+          bufferSize: 12,
+          plotMode: 0
+        }
+      ]
+    };
+    const bytesPerElement = 4;
+    const traceOptions = createTraces(traces, ARRAY_DATA, bytesPerElement);
+
+    expect(traceOptions).toEqual([
+      {
+        line: {
+          color: "rgb(250, 0, 0)",
+          width: 2
+        },
+        marker: {
+          color: "rgb(250, 0, 0)",
+          size: 6,
+          symbol: "triangle-up"
+        },
+        mode: "markers",
+        type: "scatter",
+        x: [1, 2, 3],
+        y: [3, 4, 8]
+      }
+    ]);
+  });
+
+  test("Cut data down to buffer size, first n points", (): void => {
+    const traces: Traces = {
+      count: 1,
+      pvName: "test",
+      traceOptions: [
+        {
+          index: 0,
+          traceColor: new Color("rgb(250, 0, 0)"),
+          lineWidth: 2,
+          pointStyle: 3,
+          pointSize: 6,
+          traceType: 2,
+          bufferSize: 12,
+          plotMode: 1
+        }
+      ]
+    };
+    const bytesPerElement = 4;
+    const traceOptions = createTraces(traces, ARRAY_DATA, bytesPerElement);
+
+    expect(traceOptions).toEqual([
+      {
+        line: {
+          color: "rgb(250, 0, 0)",
+          width: 2
+        },
+        marker: {
+          color: "rgb(250, 0, 0)",
+          size: 6,
+          symbol: "triangle-up"
+        },
+        mode: "markers",
+        type: "scatter",
+        x: [0, 1, 2],
+        y: [0, 3, 4]
+      }
+    ]);
+  });
+});
+
+describe("Create axis options object", (): void => {
+  test("Create axis without title label", (): void => {
+    const axes: Axis[] = [
+      {
+        index: 0,
+        axisTitle: "",
+        visible: true,
+        showGrid: true,
+        dashGridLine: false,
+        axisColor: new Color("rgb(255, 255, 255"),
+        minimum: 1,
+        maximum: 10
+      }
+    ];
+    const font = new Font(10, FontStyle.Regular, "sans");
+    const axisOptions = createAxes(axes, font.css());
+
+    expect(axisOptions).toEqual([
+      {
+        automargin: true,
+        autorange: false,
+        gridcolor: "rgb(255, 255, 255",
+        griddash: false,
+        gridwidth: 0.5,
+        minor: { ticks: "outside" },
+        range: [1, 10],
+        showgrid: true,
+        showline: true,
+        tickcolor: "rgb(255, 255, 255",
+        visible: true,
+        zeroline: false
+      }
+    ]);
+  });
+
+  test("Create axis with title label", (): void => {
+    const axes: Axis[] = [
+      {
+        index: 0,
+        axisTitle: "Test Plot",
+        visible: true,
+        showGrid: true,
+        dashGridLine: false,
+        axisColor: new Color("rgb(255, 255, 255"),
+        minimum: 1,
+        maximum: 10
+      }
+    ];
+    const font = new Font(10, FontStyle.Regular, "sans");
+    const axisOptions = createAxes(axes, font.css());
+
+    expect(axisOptions).toEqual([
+      {
+        automargin: true,
+        autorange: false,
+        gridcolor: "rgb(255, 255, 255",
+        griddash: false,
+        gridwidth: 0.5,
+        minor: { ticks: "outside" },
+        range: [1, 10],
+        showgrid: true,
+        showline: true,
+        tickcolor: "rgb(255, 255, 255",
+        title: {
+          standoff: 0,
+          text: "Test Plot"
+        },
+        titlefont: {
+          family: "sans,sans-serif",
+          size: "1rem"
+        },
+        visible: true,
+        zeroline: false
+      }
+    ]);
+  });
+
+  test("Shift axis if additional y axis", (): void => {
+    const axis = {
+      index: 0,
+      axisTitle: "Test Plot",
+      visible: true,
+      showGrid: true,
+      dashGridLine: false,
+      axisColor: new Color("rgb(255, 255, 255"),
+      minimum: 1,
+      maximum: 10
+    };
+    const axis1 = { ...axis };
+    axis1.index = 1;
+    axis1.minimum = -5;
+    const axis2 = { ...axis };
+    axis2.index = 2;
+    axis2.maximum = 50;
+    const axes: Axis[] = [axis, axis1, axis2];
+    const font = new Font(10, FontStyle.Regular, "sans");
+    const axisOptions = createAxes(axes, font.css());
+
+    // Check that third axis has shifted
+    expect(axisOptions[2]).toEqual({
+      anchor: "free",
+      automargin: true,
+      autorange: false,
+      gridcolor: "rgb(255, 255, 255",
+      griddash: false,
+      gridwidth: 0.5,
+      minor: { ticks: "outside" },
+      overlaying: "y",
+      position: 0,
+      range: [1, 50],
+      showgrid: true,
+      showline: true,
+      side: "left",
+      tickcolor: "rgb(255, 255, 255",
+      title: {
+        standoff: 0,
+        text: "Test Plot"
+      },
+      titlefont: {
+        family: "sans,sans-serif",
+        size: "1rem"
+      },
+      visible: true,
+      zeroline: false
+    });
+  });
+});

--- a/src/ui/widgets/XYPlot/xyPlotOptions.ts
+++ b/src/ui/widgets/XYPlot/xyPlotOptions.ts
@@ -151,7 +151,8 @@ export function createAxes(
       automargin: true,
       minor: {
         ticks: "outside"
-      }
+      },
+      tickformat: axis.scaleFormat
     };
     // Only add title labels if they exist
     if (axis.axisTitle !== "") {
@@ -167,13 +168,17 @@ export function createAxes(
     _newAxis.range = [axis.minimum, axis.maximum];
     _newAxis.autorange = false;
 
-    // Only shift to add space for 2nd y-axis if it is visible
-    if (idx > 1 && axis.visible) {
-      _newAxis.side = "left";
-      _newAxis.overlaying = "y";
+    if (axis.logScale) _newAxis.type = "log";
+
+    // More than 2 axes, determine position and location of axes
+    if (idx > 1) {
+      _newAxis.side = axis.leftBottomSide ? "left" : "right";
+      _newAxis.overlaying = axis.yAxis ? "y" : "x";
       _newAxis.position = 0;
       _newAxis.anchor = "free";
-      formattedAxes[0].domain = [0.08 * (axesList.length - 1), 1];
+      // Only shift to add space for 2nd y-axis if it is overlapping and visible
+      if (axis.visible)
+        formattedAxes[0].domain = [0.08 * (axesList.length - 1), 1];
     }
     formattedAxes.push(_newAxis);
     idx += 1;

--- a/src/ui/widgets/XYPlot/xyPlotOptions.ts
+++ b/src/ui/widgets/XYPlot/xyPlotOptions.ts
@@ -1,0 +1,155 @@
+import { Axis } from "../../../types/axes";
+import { PlotData } from "plotly.js";
+import { Traces } from "../../../types/traces";
+import type { DType } from "../../../types/dtypes";
+import React from "react";
+
+/**
+ * Create traces containing data for each trace
+ * specified.
+ * @param traces trace configuration
+ * @param value data from pv
+ * @returns a list of PlotData traces
+ */
+export function createTraces(
+  traces: Traces,
+  value: DType
+): Partial<PlotData>[] {
+  const arrayValue = value.value.arrayValue;
+  // TO DO - can format this better once I figure out confusing types
+  if (!arrayValue) return [];
+  const dataSet: Partial<PlotData>[] = [];
+  traces.traceOptions.forEach(options => {
+    // Create a dataset for each trace
+    const data: Partial<PlotData> = {
+      type: "scatter",
+      mode: "lines+markers",
+      line: {
+        color: options.traceColor ? options.traceColor.toString() : "green",
+        width: options.lineWidth ? options.lineWidth : 0.75
+      },
+      marker: {
+        color: options.traceColor ? options.traceColor.toString() : "green",
+        symbol: "circle",
+        size: options.pointSize ? options.pointSize : 0.75
+      }
+    };
+    const tmpX: number[] = [];
+    const tmpY: number[] = [];
+    arrayValue.forEach((val: any, ind: number) => {
+      tmpX.push(ind);
+      tmpY.push(val);
+    });
+    data.x = tmpX;
+    data.y = tmpY;
+    dataSet.push(data);
+  });
+  return dataSet;
+}
+
+/**
+ * Create plotly axis object for each axisOptions
+ * in the axes array.
+ * @param axesList list of all the axes information
+ * from the file
+ * @returns a Plotly formatted axis object
+ */
+export function createAxes(axesList: Axis[], font: React.CSSProperties): any[] {
+  const formattedAxes: any[] = [];
+  let idx = 0;
+  for (const axis of axesList) {
+    // Define type so that we can add properties to object
+    type AxisSettings = {
+      [key: string]: any;
+    };
+    const _newAxis: AxisSettings = {
+      autorange: true,
+      showline: true,
+      visible: axis.hasOwnProperty("visible") ? axis.visible : true,
+      showgrid: axis.hasOwnProperty("showGrid") ? axis.showGrid : false,
+      griddash: axis.hasOwnProperty("dashGridLine") ? axis.dashGridLine : false,
+      gridwidth: 0.5,
+      gridcolor: axis.axisColor ? axis.axisColor.toString() : "black",
+      tickcolor: axis.axisColor ? axis.axisColor.toString() : "black",
+      zeroline: false,
+      automargin: true,
+      minor: {
+        ticks: "outside"
+      }
+    };
+    // Only add title labels if they exist
+    if (axis.hasOwnProperty("axisTitle")) {
+      _newAxis.title = {
+        text: axis.axisTitle,
+        standoff: 0
+      };
+      _newAxis.titlefont = {
+        family: font ? font.fontFamily : "Liberation sans, sans-serif",
+        size: font.fontSize ? font.fontSize : 12
+      };
+    }
+    if ("minimum" in axis && "maximum" in axis) {
+      _newAxis.range = [axis.minimum, axis.maximum];
+      _newAxis.autorange = false;
+    }
+    // Only shift to add space for 2nd y-axis if it is visible
+    if (idx > 1 && axis.visible) {
+      _newAxis.side = "left";
+      _newAxis.overlaying = "y";
+      _newAxis.position = 0;
+      _newAxis.anchor = "free";
+      formattedAxes[0].domain = [0.08 * (axesList.length - 1), 1];
+    }
+    formattedAxes.push(_newAxis);
+    idx += 1;
+  }
+  return formattedAxes;
+}
+
+/**
+ * Calculates the axis range within the maximum
+ * and minimum limits using the highest and lowest
+ * data values. Defaults to range specified from file
+ * if calculated limits are larger.
+ * @param axes list of axis options
+ * @param dataSet array of PV data
+ * @returns modified list of axis options
+ */
+export function calculateAxisLimits(axes: any[], dataSet: any[]): any[] {
+  dataSet.forEach((data: any) => {
+    for (let i = 0; i < axes.length; i++) {
+      const [axMin, axMax] = axes[i].range;
+      // Determine whether we want x or y data
+      let axisData = data.y;
+      if (i === 0) axisData = data.x;
+      // Find min/max data points and round them to 1sf
+      let min = roundValue(Math.min(...axisData), 0);
+      let max = roundValue(Math.max(...axisData), 1);
+      // If number is not within axis min and max, use axis limits
+      if (typeof axMin === "number" && axMin > min) min = axMin;
+      if (typeof axMax === "number" && axMax < max) max = axMax;
+      axes[i].range = [min, max];
+    }
+  });
+  return axes;
+}
+
+/**
+ * Round a decimal value up or down to the nearest
+ * significant figure.
+ * @param value decimal value to round
+ * @param mag magnitude to round to
+ * @param roundType 0 to round down, 1 to round up
+ * @returns rounded number
+ */
+function roundValue(value: number, roundType: number): number {
+  // Can't find magnitude of 0 so skip
+  if (value === 0) return value;
+  // Need to use Math.abs to remove negative numbers
+  const mag = Math.floor(Math.log(Math.abs(value)) / Math.log(10));
+  // Round up or down depending on if it is max or min
+  if (roundType) {
+    return Math.ceil(value / Math.pow(10, mag)) * Math.pow(10, mag);
+  }
+  return Math.floor(value / Math.pow(10, mag)) * Math.pow(10, mag);
+}

--- a/src/ui/widgets/XYPlot/xyPlotOptions.ts
+++ b/src/ui/widgets/XYPlot/xyPlotOptions.ts
@@ -4,42 +4,119 @@ import { Traces } from "../../../types/traces";
 import type { DType } from "../../../types/dtypes";
 import React from "react";
 
+export type NewAxisSettings = {
+  [key: string]: any;
+};
+
+// Constants for trace properties
+
+const TRACE_STYLE: { [key: number]: any } = {
+  0: { type: "scatter", mode: "lines", line: { dash: "solid" } },
+  1: { type: "scatter", mode: "lines", line: { dash: "dash" } },
+  2: { type: "scatter", mode: "markers", line: { dash: "solid" } },
+  3: { type: "bar" },
+  4: { type: "scatter", mode: "lines", fill: "tonexty" },
+  5: { type: "scatter", mode: "lines", line: { dash: "solid" } },
+  6: { type: "scatter", mode: "lines", line: { dash: "solid" } }
+};
+
+const POINT_STYLE: { [key: number]: string } = {
+  0: "none",
+  1: "circle",
+  2: "triangle-up-open",
+  3: "triangle-up",
+  4: "square-open",
+  5: "square",
+  6: "diamond-open",
+  7: "diamond",
+  8: "cross",
+  9: "x",
+  10: "hourglass-open"
+};
+
 /**
  * Create traces containing data for each trace
  * specified.
  * @param traces trace configuration
  * @param value data from pv
+ * @param bytesPerElement number of bytes each data element
+ * has
  * @returns a list of PlotData traces
  */
 export function createTraces(
   traces: Traces,
-  value: DType
+  value: DType,
+  bytesPerElement: number
 ): Partial<PlotData>[] {
   const arrayValue = value.value.arrayValue;
   // TO DO - can format this better once I figure out confusing types
   if (!arrayValue) return [];
   const dataSet: Partial<PlotData>[] = [];
   traces.traceOptions.forEach(options => {
-    // Create a dataset for each trace
+    const traceStyle = options.traceType
+      ? TRACE_STYLE[options.traceType]
+      : TRACE_STYLE[0];
+    // Create a dataset for each trace, starting with style
     const data: Partial<PlotData> = {
-      type: "scatter",
-      mode: "lines+markers",
-      line: {
-        color: options.traceColor ? options.traceColor.toString() : "green",
-        width: options.lineWidth ? options.lineWidth : 0.75
-      },
-      marker: {
-        color: options.traceColor ? options.traceColor.toString() : "green",
-        symbol: "circle",
-        size: options.pointSize ? options.pointSize : 0.75
-      }
+      ...traceStyle
     };
-    const tmpX: number[] = [];
-    const tmpY: number[] = [];
+    data.marker = {
+      color: options.traceColor?.toString(),
+      symbol: options.pointStyle
+        ? POINT_STYLE[options.pointStyle]
+        : POINT_STYLE[0],
+      size: options.pointSize
+    };
+    // Line, scatter and area plots are similar in format options
+    if (traceStyle.type === "scatter") {
+      // different trace layout for bar and line
+      data.line = {
+        color: options.traceColor?.toString(),
+        width: options.lineWidth
+      };
+      // if area plot, fill in with same colour as line
+      if (traceStyle.fill) {
+        data.fill = traceStyle.fill;
+        data.fillcolor = options.traceColor?.toString();
+      }
+    }
+
+    // Set up actual data
+    let tmpX: number[] = [];
+    let tmpY: number[] = [];
+    let concatIdx = 0; // This number ensures x index vals aligned
+    // TO DO - figure out a way to access previous data values
+    // Currently this does NOT work
+    if (options.concatenateData && data.y) {
+      // If concatenating, keep existing data
+      data.y.forEach((val: any, ind: number) => {
+        tmpX.push(ind);
+        tmpY.push(val);
+      });
+      // Make sure new data has indexes above length
+      concatIdx = tmpX.length;
+    }
+    // Add new data values
     arrayValue.forEach((val: any, ind: number) => {
-      tmpX.push(ind);
+      tmpX.push(ind + concatIdx);
       tmpY.push(val);
     });
+
+    // Calculate number of points to plot with buffer size, default 100
+    const bufferSize = options.bufferSize ? options.bufferSize : 100;
+    // Number of points to plot
+    const numPoints = bufferSize / bytesPerElement;
+    // Reduce data if more points than buffer allows
+    if (numPoints < tmpY.length && !options.plotMode) {
+      // Use the last n points
+      tmpY = tmpY.slice(-numPoints);
+      tmpX = tmpX.slice(-numPoints);
+    } else if (numPoints < tmpY.length) {
+      // Use the first n points
+      tmpY = tmpY.slice(0, numPoints);
+      tmpX = tmpX.slice(0, numPoints);
+    }
+
     data.x = tmpX;
     data.y = tmpY;
     dataSet.push(data);
@@ -54,23 +131,22 @@ export function createTraces(
  * from the file
  * @returns a Plotly formatted axis object
  */
-export function createAxes(axesList: Axis[], font: React.CSSProperties): any[] {
+export function createAxes(
+  axesList: Axis[],
+  font: React.CSSProperties
+): NewAxisSettings[] {
   const formattedAxes: any[] = [];
   let idx = 0;
   for (const axis of axesList) {
-    // Define type so that we can add properties to object
-    type AxisSettings = {
-      [key: string]: any;
-    };
-    const _newAxis: AxisSettings = {
+    const _newAxis: NewAxisSettings = {
       autorange: true,
       showline: true,
-      visible: axis.hasOwnProperty("visible") ? axis.visible : true,
-      showgrid: axis.hasOwnProperty("showGrid") ? axis.showGrid : false,
-      griddash: axis.hasOwnProperty("dashGridLine") ? axis.dashGridLine : false,
+      visible: axis.visible,
+      showgrid: axis.showGrid,
+      griddash: axis.dashGridLine,
       gridwidth: 0.5,
-      gridcolor: axis.axisColor ? axis.axisColor.toString() : "black",
-      tickcolor: axis.axisColor ? axis.axisColor.toString() : "black",
+      gridcolor: axis.axisColor?.toString(),
+      tickcolor: axis.axisColor?.toString(),
       zeroline: false,
       automargin: true,
       minor: {
@@ -78,7 +154,7 @@ export function createAxes(axesList: Axis[], font: React.CSSProperties): any[] {
       }
     };
     // Only add title labels if they exist
-    if (axis.hasOwnProperty("axisTitle")) {
+    if (axis.axisTitle !== "") {
       _newAxis.title = {
         text: axis.axisTitle,
         standoff: 0
@@ -88,10 +164,9 @@ export function createAxes(axesList: Axis[], font: React.CSSProperties): any[] {
         size: font.fontSize ? font.fontSize : 12
       };
     }
-    if ("minimum" in axis && "maximum" in axis) {
-      _newAxis.range = [axis.minimum, axis.maximum];
-      _newAxis.autorange = false;
-    }
+    _newAxis.range = [axis.minimum, axis.maximum];
+    _newAxis.autorange = false;
+
     // Only shift to add space for 2nd y-axis if it is visible
     if (idx > 1 && axis.visible) {
       _newAxis.side = "left";
@@ -111,27 +186,43 @@ export function createAxes(axesList: Axis[], font: React.CSSProperties): any[] {
  * and minimum limits using the highest and lowest
  * data values. Defaults to range specified from file
  * if calculated limits are larger.
- * @param axes list of axis options
+ * @param oldAxis options object read from file
+ * @param newAxis plotly axis options object
  * @param dataSet array of PV data
- * @returns modified list of axis options
+ * @param index the index of the axis
+ * @returns modified axis options object
  */
-export function calculateAxisLimits(axes: any[], dataSet: any[]): any[] {
-  dataSet.forEach((data: any) => {
-    for (let i = 0; i < axes.length; i++) {
-      const [axMin, axMax] = axes[i].range;
-      // Determine whether we want x or y data
-      let axisData = data.y;
-      if (i === 0) axisData = data.x;
-      // Find min/max data points and round them to 1sf
-      let min = roundValue(Math.min(...axisData), 0);
-      let max = roundValue(Math.max(...axisData), 1);
-      // If number is not within axis min and max, use axis limits
-      if (typeof axMin === "number" && axMin > min) min = axMin;
-      if (typeof axMax === "number" && axMax < max) max = axMax;
-      axes[i].range = [min, max];
-    }
-  });
-  return axes;
+export function calculateAxisLimits(
+  oldAxis: Axis,
+  newAxis: NewAxisSettings,
+  dataSet: any[]
+): NewAxisSettings {
+  // If autoscale not enabled, do not rescale axes
+  if (!oldAxis.autoScale) return newAxis;
+  // Find axis limits
+  const [axMin, axMax]: [number, number] = newAxis.range;
+  // Determine if we are using x or y data
+  let dataType = "x";
+  if (oldAxis.index > 0 && oldAxis.yAxis) dataType = "y";
+  // Combine all data we need into an array of arrays
+  const allData = dataSet.map(val => val[dataType]);
+  // Find max and minimum value from all the traces and round to 1sf
+  const actualMin = Math.min(...[].concat(...allData));
+  const actualMax = Math.max(...[].concat(...allData));
+  let min = roundValue(Math.min(actualMin), 0);
+  let max = roundValue(Math.max(actualMax), 1);
+  // If number is within autoscale threshold, just use axis limits
+  const threshold = 1 - (max - min) / (axMax - axMin);
+  if (
+    oldAxis.autoScaleThreshold &&
+    -oldAxis.autoScaleThreshold < threshold &&
+    threshold < oldAxis.autoScaleThreshold
+  ) {
+    min = axMin;
+    max = axMax;
+  }
+  newAxis.range = [min, max];
+  return newAxis;
 }
 
 /**
@@ -142,14 +233,22 @@ export function calculateAxisLimits(axes: any[], dataSet: any[]): any[] {
  * @param roundType 0 to round down, 1 to round up
  * @returns rounded number
  */
-function roundValue(value: number, roundType: number): number {
+export function roundValue(value: number, roundType: number): number {
   // Can't find magnitude of 0 so skip
   if (value === 0) return value;
   // Need to use Math.abs to remove negative numbers
   const mag = Math.floor(Math.log(Math.abs(value)) / Math.log(10));
   // Round up or down depending on if it is max or min
   if (roundType) {
-    return Math.ceil(value / Math.pow(10, mag)) * Math.pow(10, mag);
+    return parseFloat(
+      (Math.ceil(value / Math.pow(10, mag)) * Math.pow(10, mag)).toPrecision(
+        Math.abs(mag) + 1
+      )
+    );
   }
-  return Math.floor(value / Math.pow(10, mag)) * Math.pow(10, mag);
+  return parseFloat(
+    (Math.floor(value / Math.pow(10, mag)) * Math.pow(10, mag)).toPrecision(
+      Math.abs(mag) + 1
+    )
+  );
 }

--- a/src/ui/widgets/index.ts
+++ b/src/ui/widgets/index.ts
@@ -27,6 +27,7 @@ export { Slideshow } from "./Slideshow/slideshow";
 export { Symbol } from "./Symbol/symbol";
 export { TabBar } from "./Tabs/tabs";
 export { DynamicTabs } from "./Tabs/dynamicTabs";
+export { XYPlot } from "./XYPlot/xyPlot";
 
 // By importing and calling this function you ensure all the
 // above widgets are imported and thus registered.

--- a/src/ui/widgets/propTypes.ts
+++ b/src/ui/widgets/propTypes.ts
@@ -5,6 +5,8 @@ import { Border } from "../../types/border";
 import { RelativePosition, AbsolutePosition } from "../../types/position";
 import { PV } from "../../types/pv";
 import { FileDescription } from "../../misc/fileContext";
+import { Traces } from "../../types/traces";
+import { Axes } from "../../types/axes";
 
 export type ExcludeNulls<T> = {
   [P in keyof T]: Exclude<T[P], null>;
@@ -40,6 +42,12 @@ export const FontPropOpt = PropTypes.instanceOf(Font);
 
 export const BorderProp = PropTypes.instanceOf(Border).isRequired;
 export const BorderPropOpt = PropTypes.instanceOf(Border);
+
+export const TracesProp = PropTypes.instanceOf(Traces).isRequired;
+export const TracesPropOpt = PropTypes.instanceOf(Traces);
+
+export const AxesProp = PropTypes.instanceOf(Axes).isRequired;
+export const AxesPropOpt = PropTypes.instanceOf(Axes);
 
 export const FuncPropOpt = PropTypes.instanceOf(Function);
 export const FuncProp = FuncPropOpt.isRequired;

--- a/src/ui/widgets/utils.ts
+++ b/src/ui/widgets/utils.ts
@@ -2,16 +2,17 @@
  * Converts string from snake case to camel
  * case.
  * @param text string to convert
- * @param sliceIdx number to slice at and remove elements
+ * @param start first index of string to convert
+ * @param end final index of string to convert
  * @returns newly formatted string
  */
 export function snakeCaseToCamelCase(
   text: string,
-  start = undefined,
-  end = undefined
+  start: number | undefined,
+  end: number | undefined
 ): string | undefined {
-  // Split string by underscore
-  const stringArray = text.split("_").slice(start, end);
+  // Remove unneeded characters then split string by underscore
+  const stringArray = text.slice(start, end).split("_");
   // Remove first element, this shouldn't be uppercase
   let newName = stringArray.shift();
   // Loop over and capitalise first character of each string

--- a/src/ui/widgets/utils.ts
+++ b/src/ui/widgets/utils.ts
@@ -1,0 +1,64 @@
+/**
+ * Converts string from snake case to camel
+ * case.
+ * @param text string to convert
+ * @param sliceIdx number to slice at and remove elements
+ * @returns newly formatted string
+ */
+export function snakeCaseToCamelCase(
+  text: string,
+  start = undefined,
+  end = undefined
+): string | undefined {
+  // Split string by underscore
+  const stringArray = text.split("_").slice(start, end);
+  // Remove first element, this shouldn't be uppercase
+  let newName = stringArray.shift();
+  // Loop over and capitalise first character of each string
+  stringArray.forEach((word: string) => {
+    newName += word.charAt(0).toUpperCase() + word.slice(1);
+  });
+  return newName;
+}
+
+/**
+ * Round a decimal value up or down to the nearest
+ * significant figure.
+ * @param value decimal value to round
+ * @param mag magnitude to round to
+ * @param roundType 0 to round down, 1 to round up
+ * @returns rounded number
+ */
+export function roundValue(value: number, roundType: number): number {
+  // Can't find magnitude of 0 so skip
+  if (value === 0) return value;
+  // Need to use Math.abs to remove negative numbers
+  const mag = Math.floor(Math.log(Math.abs(value)) / Math.log(10));
+  // Round up or down depending on if it is max or min
+  if (roundType) {
+    return parseFloat(
+      (Math.ceil(value / Math.pow(10, mag)) * Math.pow(10, mag)).toPrecision(
+        Math.abs(mag) + 1
+      )
+    );
+  }
+  return parseFloat(
+    (Math.floor(value / Math.pow(10, mag)) * Math.pow(10, mag)).toPrecision(
+      Math.abs(mag) + 1
+    )
+  );
+}
+
+/**
+ * If the height/width string contains "px" or font size
+ * string contains "rem", remove it and convert value to
+ * number.
+ */
+export function trimFromString(value: string): number {
+  let num = 0;
+  if (typeof value === "string") {
+    if (value.includes("px")) num = Number(value.slice(0, -2));
+    if (value.includes("rem")) num = Number(value.slice(0, -3)) * 10;
+  }
+  return num;
+}


### PR DESCRIPTION
I created an XYPlot widget based on the `dawn.xygraph` and `xygraph` widgets that uses plotly.js/react-plotly.js as the plotting library. It is able to mimic most of the existing functionality provided by CSStudio with plotly.js settings, and uses the same default values for properties. It does not currently have the ability to concatenate new data onto already plotted data. 

Some other things to note:

- The names in the .opi file for trace/axis properties are difficult to parse, so I would very much appreciate any feedback on better ways to implement the parsing! 
- Currently cs-web-lib does not correctly resolve nested macro names for PVs, as mentioned in the [Not yet implemented section in the cs-web-proto wiki](https://github.com/dls-controls/cs-web-proto/wiki/Macros). As xygraph widgets contain nested macro names, I have added a small hack to ensure they're parsed correctly in this one use case. Fixing the overall issue seemed like it could be a big divergence from the plot widget focus