### PR TITLE
Webcam widget

### DIFF
--- a/src/ui/widgets/Webcam/webcam.module.css
+++ b/src/ui/widgets/Webcam/webcam.module.css
@@ -1,0 +1,5 @@
+img {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+}

--- a/src/ui/widgets/Webcam/webcam.test.tsx
+++ b/src/ui/widgets/Webcam/webcam.test.tsx
@@ -34,7 +34,7 @@ describe("<Webcam />", (): void => {
     );
     expect(
       getByAltText(
-        "Connection could not be made to Webcam MJPEG stream at http://fake-stream.diamond.ac.uk/video.mjpg"
+        "Connection to webcam at http://fake-stream.diamond.ac.uk/video.mjpg failed"
       )
     ).toBeInTheDocument();
   });

--- a/src/ui/widgets/Webcam/webcam.test.tsx
+++ b/src/ui/widgets/Webcam/webcam.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { contextRender } from "../../../testResources";
 import { fireEvent } from "@testing-library/react";
-import { Webcam, WebcamComponent } from "./webcam";
+import { WebcamComponent } from "./webcam";
 
 describe("<Webcam />", (): void => {
   test("it displays the alt text while loading", (): void => {

--- a/src/ui/widgets/Webcam/webcam.test.tsx
+++ b/src/ui/widgets/Webcam/webcam.test.tsx
@@ -1,19 +1,19 @@
 import React from "react";
 import { contextRender } from "../../../testResources";
 import { fireEvent } from "@testing-library/react";
-import { Webcam } from "./webcam";
+import { Webcam, WebcamComponent } from "./webcam";
 
 describe("<Webcam />", (): void => {
   test("it displays the alt text while loading", (): void => {
     const { getByAltText } = contextRender(
-      <Webcam url="http://fake-stream.diamond.ac.uk/video.mjpg" />
+      <WebcamComponent url="http://fake-stream.diamond.ac.uk/video.mjpg" />
     );
     expect(getByAltText("Loading Webcam MJPEG stream...")).toBeInTheDocument();
   });
 
   test("it displays the alt text once loaded", (): void => {
     const { getByAltText } = contextRender(
-      <Webcam url="http://fake-stream.diamond.ac.uk/video.mjpg" />
+      <WebcamComponent url="http://fake-stream.diamond.ac.uk/video.mjpg" />
     );
     fireEvent.load(
       getByAltText("Loading Webcam MJPEG stream...") as HTMLImageElement
@@ -27,7 +27,7 @@ describe("<Webcam />", (): void => {
 
   test("it displays the alt text when error occurs", (): void => {
     const { getByAltText } = contextRender(
-      <Webcam url="http://fake-stream.diamond.ac.uk/video.mjpg" />
+      <WebcamComponent url="http://fake-stream.diamond.ac.uk/video.mjpg" />
     );
     fireEvent.error(
       getByAltText("Loading Webcam MJPEG stream...") as HTMLImageElement

--- a/src/ui/widgets/Webcam/webcam.test.tsx
+++ b/src/ui/widgets/Webcam/webcam.test.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { contextRender } from "../../../testResources";
+import { fireEvent } from "@testing-library/react";
+import { Webcam } from "./webcam";
+
+describe("<Webcam />", (): void => {
+  test("it displays the alt text while loading", (): void => {
+    const { getByAltText } = contextRender(
+      <Webcam url="http://fake-stream.diamond.ac.uk/video.mjpg" />
+    );
+    expect(getByAltText("Loading Webcam MJPEG stream...")).toBeInTheDocument();
+  });
+
+  test("it displays the alt text once loaded", (): void => {
+    const { getByAltText } = contextRender(
+      <Webcam url="http://fake-stream.diamond.ac.uk/video.mjpg" />
+    );
+    fireEvent.load(
+      getByAltText("Loading Webcam MJPEG stream...") as HTMLImageElement
+    );
+    expect(
+      getByAltText(
+        "Webcam MJPEG stream at http://fake-stream.diamond.ac.uk/video.mjpg"
+      )
+    ).toBeInTheDocument();
+  });
+
+  test("it displays the alt text when error occurs", (): void => {
+    const { getByAltText } = contextRender(
+      <Webcam url="http://fake-stream.diamond.ac.uk/video.mjpg" />
+    );
+    fireEvent.error(
+      getByAltText("Loading Webcam MJPEG stream...") as HTMLImageElement
+    );
+    expect(
+      getByAltText(
+        "Connection could not be made to Webcam MJPEG stream at http://fake-stream.diamond.ac.uk/video.mjpg"
+      )
+    ).toBeInTheDocument();
+  });
+});

--- a/src/ui/widgets/Webcam/webcam.tsx
+++ b/src/ui/widgets/Webcam/webcam.tsx
@@ -39,9 +39,8 @@ export const Webcam = (props: { url: string }): JSX.Element => {
  */
 function onError() {
   const image = document.getElementById("stream") as HTMLImageElement;
-  const alt = `Connection could not be made to Webcam MJPEG stream at ${image.src}`;
+  const alt = `Connection to webcam at ${image.src} failed`;
   (document.getElementById("stream") as HTMLImageElement).alt = alt;
-  console.error(`Connection to ${image.src} failed`);
 }
 
 /**

--- a/src/ui/widgets/Webcam/webcam.tsx
+++ b/src/ui/widgets/Webcam/webcam.tsx
@@ -1,0 +1,79 @@
+import React, { useState, useEffect } from "react";
+import classes from "./webcam.module.css";
+
+/**
+ * Creates a Webcam component for displaying MJPEG
+ * streams
+ * @param props url of webcam stream
+ * @returns HTML component
+ */
+export const Webcam = (props: { url: string }): JSX.Element => {
+  const { width, height } = useWindowDimensions();
+  // Create image tag
+  const webcamImg = (
+    <div
+      style={{
+        height: height,
+        width: width,
+        fontSize: "14px", // Set properties for image alt text
+        fontWeight: "bold",
+        color: "#a6190f"
+      }}
+    >
+      <img
+        id="stream"
+        className={classes.img}
+        src={props.url}
+        alt={`Loading Webcam MJPEG stream...`}
+        onError={onError}
+        onLoad={onLoad}
+      />
+    </div>
+  );
+  return webcamImg;
+};
+
+/**
+ * Returns an error visible to the user when the MJPEG stream
+ * at the given URL cannot be reached.
+ */
+function onError() {
+  const image = document.getElementById("stream") as HTMLImageElement;
+  const alt = `Connection could not be made to Webcam MJPEG stream at ${image.src}`;
+  (document.getElementById("stream") as HTMLImageElement).alt = alt;
+  console.error(`Connection to ${image.src} failed`);
+}
+
+/**
+ * Changes image alt text once image is loaded.
+ */
+function onLoad() {
+  const image = document.getElementById("stream") as HTMLImageElement;
+  const alt = `Webcam MJPEG stream at ${image.src}`;
+  (document.getElementById("stream") as HTMLImageElement).alt = alt;
+}
+
+function getWindowDimensions() {
+  const { innerWidth: width, innerHeight: height } = window;
+  return {
+    width,
+    height
+  };
+}
+
+function useWindowDimensions() {
+  const [windowDimensions, setWindowDimensions] = useState(
+    getWindowDimensions()
+  );
+
+  useEffect(() => {
+    function handleResize() {
+      setWindowDimensions(getWindowDimensions());
+    }
+
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
+  return windowDimensions;
+}

--- a/src/ui/widgets/Webcam/webcam.tsx
+++ b/src/ui/widgets/Webcam/webcam.tsx
@@ -1,5 +1,13 @@
 import React, { useState, useEffect } from "react";
 import classes from "./webcam.module.css";
+import { StringPropOpt, InferWidgetProps } from "../propTypes";
+import { WidgetPropType } from "../widgetProps";
+import { Widget } from "../widget";
+import { registerWidget } from "../register";
+
+const WebcamProps = {
+  url: StringPropOpt
+};
 
 /**
  * Creates a Webcam component for displaying MJPEG
@@ -7,10 +15,12 @@ import classes from "./webcam.module.css";
  * @param props url of webcam stream
  * @returns HTML component
  */
-export const Webcam = (props: { url: string }): JSX.Element => {
+export const WebcamComponent = (
+  props: InferWidgetProps<typeof WebcamProps>
+): JSX.Element => {
   const { width, height } = useWindowDimensions();
   // Create image tag
-  const webcamImg = (
+  return (
     <div
       style={{
         height: height,
@@ -30,7 +40,6 @@ export const Webcam = (props: { url: string }): JSX.Element => {
       />
     </div>
   );
-  return webcamImg;
 };
 
 /**
@@ -76,3 +85,14 @@ function useWindowDimensions() {
 
   return windowDimensions;
 }
+
+const WebcamWidgetProps = {
+  ...WebcamProps,
+  ...WidgetPropType
+};
+
+export const Webcam = (
+  props: InferWidgetProps<typeof WebcamWidgetProps>
+): JSX.Element => <Widget baseWidget={WebcamComponent} {...props} />;
+
+registerWidget(Webcam, WebcamWidgetProps, "webcam");

--- a/src/ui/widgets/index.ts
+++ b/src/ui/widgets/index.ts
@@ -27,6 +27,7 @@ export { Slideshow } from "./Slideshow/slideshow";
 export { Symbol } from "./Symbol/symbol";
 export { TabBar } from "./Tabs/tabs";
 export { DynamicTabs } from "./Tabs/dynamicTabs";
+export { Webcam } from "./Webcam/webcam";
 
 // By importing and calling this function you ensure all the
 // above widgets are imported and thus registered.


### PR DESCRIPTION
A webcam widget that displays MJPEG streams (or other compatible formats) in a HTML image. The widget expands to fill the entire window and maintains aspect ratio when window is resized in any direction. If a connection cannot be made, the alt text displays an error message informing the viewer of this.