### PR TITLE
Fix errors thrown when disconnected

### DIFF
--- a/src/connection/coniql.test.ts
+++ b/src/connection/coniql.test.ts
@@ -136,4 +136,8 @@ describe("ConiqlPlugin", (): void => {
       variables: { device: "stuff" }
     });
   });
+
+  it("unsubscribes_with_no_errors", (): void => {
+    expect(() => cp.unsubscribe("hello")).not.toThrow(TypeError);
+  });
 });

--- a/src/connection/coniql.ts
+++ b/src/connection/coniql.ts
@@ -307,7 +307,7 @@ export class ConiqlPlugin implements Connection {
       {
         applyMiddleware(options: OperationOptions, next: any) {
           if (!acknowledgementReceived) {
-            throw new Error("Acknowledgement not received from server.");
+            log.warn("Acknowledgement not received from server.");
           }
           next();
         }
@@ -497,7 +497,9 @@ export class ConiqlPlugin implements Connection {
     // Note that connectionMiddleware handles multiple subscriptions
     // for the same PV at present, so if this method is called then
     // there is no further need for this PV.
-    this.subscriptions[pvName].unsubscribe();
-    delete this.subscriptions[pvName];
+    if (this.subscriptions[pvName]) {
+      this.subscriptions[pvName].unsubscribe();
+      delete this.subscriptions[pvName];
+    }
   }
 }


### PR DESCRIPTION
Fix errors thrown by the client when disconnected from the Conqil websocket. The console was full of unnecessary errors which could be logged as warnings. 
There was also a case where it tried to unsubscribe from a PV that it was not subscribed to and hence tried to remove a PV from a list that did not contain it throwing an error. 
With a page that has many PVs that are disconnected this becomes a lots of logged errors.
Refer to issue #17. 