### PR TITLE
Fix Issue #18 dependency warnings on install

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,12 @@
       "license": "ISC",
       "dependencies": {
         "apollo-link-retry": "^2.2.16",
+        "bufferutil": "^4.0.7",
         "loglevel": "^1.8.0",
         "plotly.js": "^2.17.1",
         "react-plotly.js": "^2.6.0",
-        "redux": "^4.1.2"
+        "redux": "^4.1.2",
+        "utf-8-validate": "^5.0.10"
       },
       "devDependencies": {
         "@apollo/client": "^3.3.19",
@@ -22,7 +24,7 @@
         "@rollup/plugin-node-resolve": "^13.1.3",
         "@rollup/plugin-typescript": "^8.3.0",
         "@testing-library/jest-dom": "^5.16.2",
-        "@testing-library/react": "^12.1.3",
+        "@testing-library/react": "^12.0.0",
         "@types/jest": "^27.4.0",
         "@types/node": "^17.0.18",
         "@types/react-plotly.js": "^2.5.2",
@@ -37,7 +39,7 @@
         "prettier": "^2.2.1",
         "react-id-generator": "^3.0.0",
         "react-scripts": "^4.0.3",
-        "react-test-renderer": "^17.0.2",
+        "react-test-renderer": "^17.0.0",
         "react-tiny-popover": "^6.0.10",
         "rollup": "^2.63.0",
         "rollup-plugin-dts": "^4.1.0",
@@ -51,7 +53,7 @@
       "peerDependencies": {
         "@types/react": "^17.0.38",
         "@types/react-router-dom": "^5.1.2",
-        "react": "^17.0.2",
+        "react": "^17.0.0",
         "react-redux": "^7.1.3",
         "react-router-dom": "^5.2.0"
       }
@@ -5914,6 +5916,18 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
+    },
+    "node_modules/bufferutil": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.7.tgz",
+      "integrity": "sha512-kukuqc39WOHtdxtw4UScxF/WVnMFVSQVKhtx3AjZJzhd0RGZZldcrfSEbVsWWe6KNH253574cq5F+wpv0G9pJw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
     },
     "node_modules/builtin-modules": {
       "version": "3.2.0",
@@ -15139,6 +15153,16 @@
       "dev": true,
       "engines": {
         "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
+      "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/node-int64": {
@@ -25937,6 +25961,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
     "node_modules/util": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",
@@ -32928,6 +32964,14 @@
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
       "dev": true
+    },
+    "bufferutil": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.7.tgz",
+      "integrity": "sha512-kukuqc39WOHtdxtw4UScxF/WVnMFVSQVKhtx3AjZJzhd0RGZZldcrfSEbVsWWe6KNH253574cq5F+wpv0G9pJw==",
+      "requires": {
+        "node-gyp-build": "^4.3.0"
+      }
     },
     "builtin-modules": {
       "version": "3.2.0",
@@ -40311,6 +40355,11 @@
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
       "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
       "dev": true
+    },
+    "node-gyp-build": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
+      "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ=="
     },
     "node-int64": {
       "version": "0.4.0",
@@ -48726,6 +48775,14 @@
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
+    },
+    "utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "requires": {
+        "node-gyp-build": "^4.3.0"
+      }
     },
     "util": {
       "version": "0.11.1",

--- a/package.json
+++ b/package.json
@@ -19,10 +19,12 @@
   },
   "dependencies": {
     "apollo-link-retry": "^2.2.16",
+    "bufferutil": "^4.0.7",
     "loglevel": "^1.8.0",
     "plotly.js": "^2.17.1",
     "react-plotly.js": "^2.6.0",
-    "redux": "^4.1.2"
+    "redux": "^4.1.2",
+    "utf-8-validate": "^5.0.10"
   },
   "devDependencies": {
     "@apollo/client": "^3.3.19",
@@ -31,7 +33,7 @@
     "@rollup/plugin-node-resolve": "^13.1.3",
     "@rollup/plugin-typescript": "^8.3.0",
     "@testing-library/jest-dom": "^5.16.2",
-    "@testing-library/react": "^12.1.3",
+    "@testing-library/react": "^12.0.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^17.0.18",
     "@types/react-plotly.js": "^2.5.2",
@@ -46,7 +48,7 @@
     "prettier": "^2.2.1",
     "react-id-generator": "^3.0.0",
     "react-scripts": "^4.0.3",
-    "react-test-renderer": "^17.0.2",
+    "react-test-renderer": "^17.0.0",
     "react-tiny-popover": "^6.0.10",
     "rollup": "^2.63.0",
     "rollup-plugin-dts": "^4.1.0",
@@ -60,7 +62,7 @@
   "peerDependencies": {
     "@types/react": "^17.0.38",
     "@types/react-router-dom": "^5.1.2",
-    "react": "^17.0.2",
+    "react": "^17.0.0",
     "react-redux": "^7.1.3",
     "react-router-dom": "^5.2.0"
   },


### PR DESCRIPTION
This addresses the dependency issues mentioned in #18:

- Peer dependency on React 17.0.2 and above has been changed to 17.0.0 upwards. 
- Packages missing from the distribution (bufferutil and utf-8-validate) are now included