### PR TITLE
Configure CSS to honour line breaks

### DIFF
--- a/src/ui/widgets/Label/label.tsx
+++ b/src/ui/widgets/Label/label.tsx
@@ -86,6 +86,7 @@ export const LabelComponent = (
 
   if (wrapWords) {
     style["wordBreak"] = "break-word";
+    style["whiteSpace"] = "break-spaces";
   }
 
   // Simple component to display text - defaults to black text and dark grey background


### PR DESCRIPTION
A previous fix was attempted in #9 by removing the CSS 'white-space' property. This was not the correct solution. The documentation suggests that the correct setting for this property is 'break-space' (see https://developer.mozilla.org/en-US/docs/Web/CSS/white-space for a definition).