### PR TITLE
Update webcam to display multiple on page

### DIFF
--- a/src/ui/widgets/Webcam/webcam.module.css
+++ b/src/ui/widgets/Webcam/webcam.module.css
@@ -1,5 +1,9 @@
 img {
+    max-width: 100%;
+    min-width:100%;
+    min-height: 100%;
     width: 100%;
     height: 100%;
     object-fit: contain;
+    overflow: hidden;
 }

--- a/src/ui/widgets/Webcam/webcam.test.tsx
+++ b/src/ui/widgets/Webcam/webcam.test.tsx
@@ -6,14 +6,20 @@ import { WebcamComponent } from "./webcam";
 describe("<Webcam />", (): void => {
   test("it displays the alt text while loading", (): void => {
     const { getByAltText } = contextRender(
-      <WebcamComponent url="http://fake-stream.diamond.ac.uk/video.mjpg" />
+      <WebcamComponent
+        url="http://fake-stream.diamond.ac.uk/video.mjpg"
+        name="one"
+      />
     );
     expect(getByAltText("Loading Webcam MJPEG stream...")).toBeInTheDocument();
   });
 
   test("it displays the alt text once loaded", (): void => {
     const { getByAltText } = contextRender(
-      <WebcamComponent url="http://fake-stream.diamond.ac.uk/video.mjpg" />
+      <WebcamComponent
+        url="http://fake-stream.diamond.ac.uk/video.mjpg"
+        name="two"
+      />
     );
     fireEvent.load(
       getByAltText("Loading Webcam MJPEG stream...") as HTMLImageElement
@@ -27,7 +33,10 @@ describe("<Webcam />", (): void => {
 
   test("it displays the alt text when error occurs", (): void => {
     const { getByAltText } = contextRender(
-      <WebcamComponent url="http://fake-stream.diamond.ac.uk/video.mjpg" />
+      <WebcamComponent
+        url="http://fake-stream.diamond.ac.uk/video.mjpg"
+        name="three"
+      />
     );
     fireEvent.error(
       getByAltText("Loading Webcam MJPEG stream...") as HTMLImageElement

--- a/src/ui/widgets/Webcam/webcam.tsx
+++ b/src/ui/widgets/Webcam/webcam.tsx
@@ -47,7 +47,7 @@ export const WebcamComponent = (
 function onError(event: any) {
   const image = document.getElementById(event.target.id) as HTMLImageElement;
   const alt = `Connection to webcam at ${image.src} failed`;
-  (document.getElementById(event.target.id) as HTMLImageElement).alt = alt;
+  image.alt = alt;
 }
 
 /**
@@ -56,7 +56,7 @@ function onError(event: any) {
 function onLoad(event: any) {
   const image = document.getElementById(event.target.id) as HTMLImageElement;
   const alt = `Webcam MJPEG stream at ${image.src}`;
-  (document.getElementById(event.target.id) as HTMLImageElement).alt = alt;
+  image.alt = alt;
 }
 
 const WebcamWidgetProps = {

--- a/src/ui/widgets/Webcam/webcam.tsx
+++ b/src/ui/widgets/Webcam/webcam.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React from "react";
 import classes from "./webcam.module.css";
 import { StringPropOpt, InferWidgetProps } from "../propTypes";
 import { WidgetPropType } from "../widgetProps";
@@ -6,6 +6,7 @@ import { Widget } from "../widget";
 import { registerWidget } from "../register";
 
 const WebcamProps = {
+  name: StringPropOpt,
   url: StringPropOpt
 };
 
@@ -18,20 +19,17 @@ const WebcamProps = {
 export const WebcamComponent = (
   props: InferWidgetProps<typeof WebcamProps>
 ): JSX.Element => {
-  const { width, height } = useWindowDimensions();
   // Create image tag
   return (
     <div
       style={{
-        height: height,
-        width: width,
         fontSize: "14px", // Set properties for image alt text
         fontWeight: "bold",
         color: "#a6190f"
       }}
     >
       <img
-        id="stream"
+        id={props.name}
         className={classes.img}
         src={props.url}
         alt={`Loading Webcam MJPEG stream...`}
@@ -46,44 +44,19 @@ export const WebcamComponent = (
  * Returns an error visible to the user when the MJPEG stream
  * at the given URL cannot be reached.
  */
-function onError() {
-  const image = document.getElementById("stream") as HTMLImageElement;
+function onError(event: any) {
+  const image = document.getElementById(event.target.id) as HTMLImageElement;
   const alt = `Connection to webcam at ${image.src} failed`;
-  (document.getElementById("stream") as HTMLImageElement).alt = alt;
+  (document.getElementById(event.target.id) as HTMLImageElement).alt = alt;
 }
 
 /**
  * Changes image alt text once image is loaded.
  */
-function onLoad() {
-  const image = document.getElementById("stream") as HTMLImageElement;
+function onLoad(event: any) {
+  const image = document.getElementById(event.target.id) as HTMLImageElement;
   const alt = `Webcam MJPEG stream at ${image.src}`;
-  (document.getElementById("stream") as HTMLImageElement).alt = alt;
-}
-
-function getWindowDimensions() {
-  const { innerWidth: width, innerHeight: height } = window;
-  return {
-    width,
-    height
-  };
-}
-
-function useWindowDimensions() {
-  const [windowDimensions, setWindowDimensions] = useState(
-    getWindowDimensions()
-  );
-
-  useEffect(() => {
-    function handleResize() {
-      setWindowDimensions(getWindowDimensions());
-    }
-
-    window.addEventListener("resize", handleResize);
-    return () => window.removeEventListener("resize", handleResize);
-  }, []);
-
-  return windowDimensions;
+  (document.getElementById(event.target.id) as HTMLImageElement).alt = alt;
 }
 
 const WebcamWidgetProps = {


### PR DESCRIPTION
The previous implementation of the webcam widget only allowed for a single one to be displayed per page - this was due to auto-sizing of the widget being based on the window size and each webcam widget having the same id. I have updated this now so that the scaling of webcams depends on the size of parent element, and each accepts a name/id to differentiate them. The tests have also been updated for the addition of an id/name.

The webcam sizing isn't ideal as if you attempt to make the page smaller than the original webcam size l it does not shrink, but instead starts to crop the edges. I haven't figured out the exact CSS needed to achieve this.