### PR TITLE
Ensure webcam widget size doesn't overflow container

### DIFF
--- a/src/ui/widgets/Webcam/webcam.tsx
+++ b/src/ui/widgets/Webcam/webcam.tsx
@@ -23,6 +23,8 @@ export const WebcamComponent = (
   return (
     <div
       style={{
+        width: "100%",
+        height: "100%",
         fontSize: "14px", // Set properties for image alt text
         fontWeight: "bold",
         color: "#a6190f"


### PR DESCRIPTION
While implementing webcam SDMs in machine-status I noticed that despite setting `object-fit: contain` in webcam.module.css, the `img` element of the Webcam widget frequently overflows the boundaries of its parent container. This often means that the Webcam is not fully displayed on the screen. I traced the source of this to the `div` element that makes up the first layer of the Webcam widget. Because this did not have height or width specified it was expanding past the height and width of the parent element, and therefore making the `img` element overflow too. Adding in height and width ensures that the webcam widget now fills the available space but does not overflow past it, while still maintaining the aspect ratio.