### PR TITLE
Export components needed in cs-web-proto

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,4 @@
 export { AbsolutePosition } from "./position";
 export { RelativePosition } from "./position";
 export { Color } from "./color";
+export { PV } from "./pv";

--- a/src/ui/components/index.ts
+++ b/src/ui/components/index.ts
@@ -1,2 +1,3 @@
 export { Footer } from "./Footer/footer";
 export { Header } from "./Header/header";
+export { InputComponent } from "./input/input";


### PR DESCRIPTION
These two components are needed by the performancePage in cs-web-proto but they are not exported by cs-web-lib so it cannot access them. This PR simply exports these components so that applications can use them from the library.