### PR TITLE
Export functions required for cs-web-proto header and footer

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,3 +3,4 @@ export * from "./misc";
 export * from "./ui/components";
 export * from "./ui/widgets";
 export * from "./types";
+export { contextRender } from "./testResources";

--- a/src/misc/index.ts
+++ b/src/misc/index.ts
@@ -1,3 +1,3 @@
 export { onRenderCallback } from "./profilerCallback";
 export { FileProvider } from "./fileContext";
-export { OutlineProvider } from "./outlineContext";
+export { OutlineContext, OutlineProvider } from "./outlineContext";

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,3 +2,5 @@ export { AbsolutePosition } from "./position";
 export { RelativePosition } from "./position";
 export { Color } from "./color";
 export { PV } from "./pv";
+export { Font, FontStyle } from "./font";
+export { Border, BorderStyle } from "./border";

--- a/src/ui/components/index.ts
+++ b/src/ui/components/index.ts
@@ -1,1 +1,3 @@
+export { Footer } from "./Footer/footer";
+export { Header } from "./Header/header";
 export { InputComponent } from "./input/input";

--- a/src/ui/components/index.ts
+++ b/src/ui/components/index.ts
@@ -1,3 +1,1 @@
-export { Footer } from "./Footer/footer";
-export { Header } from "./Header/header";
 export { InputComponent } from "./input/input";


### PR DESCRIPTION
After removing the footer and header components from cs-web-lib (see #32), we need to add them into the cs-web-proto application. These require further exports of functions from cs-web-lib.