### PR TITLE
Fix autoZoomToFit scaling for all observed use-cases

### DIFF
--- a/src/ui/widgets/Display/display.tsx
+++ b/src/ui/widgets/Display/display.tsx
@@ -26,7 +26,8 @@ const DisplayProps = {
   border: BorderPropOpt,
   macros: MacrosPropOpt,
   scaling: StringPropOpt,
-  autoZoomToFit: BoolPropOpt
+  autoZoomToFit: BoolPropOpt,
+  scalingOrigin: StringPropOpt
 };
 
 // Generic display widget to put other things inside
@@ -54,11 +55,15 @@ export const DisplayComponent = (
   style["position"] = "relative";
   style["overflow"] = props.overflow;
   style["height"] = "100%";
-  if (props.autoZoomToFit) {
-    const internalScale =
-      typeof props.scaling === "undefined" ? "1" : props.scaling;
+  const internalScale =
+    typeof props.scaling === "undefined" ? "1" : props.scaling;
+  if (props.autoZoomToFit && internalScale !== "1") {
     style["transform"] = "scale(" + internalScale + ")";
-    style["transformOrigin"] = "center top";
+    const scalingOrigin =
+      typeof props.scalingOrigin === "undefined"
+        ? "center top"
+        : props.scalingOrigin;
+    style["transformOrigin"] = scalingOrigin;
   }
   return (
     <MacroContext.Provider value={displayMacroContext}>

--- a/src/ui/widgets/Display/display.tsx
+++ b/src/ui/widgets/Display/display.tsx
@@ -18,6 +18,7 @@ import {
   MacroContext,
   MacroContextType
 } from "../../../types/macros";
+import { getOptionalValue } from "../utils";
 
 const DisplayProps = {
   children: ChildrenPropOpt,
@@ -55,14 +56,15 @@ export const DisplayComponent = (
   style["position"] = "relative";
   style["overflow"] = props.overflow;
   style["height"] = "100%";
-  const internalScale =
-    typeof props.scaling === "undefined" ? "1" : props.scaling;
+  // Check whether the scaling property has been set and if
+  // not set the scaling to 1 (i.e. no scaling)
+  const internalScale = getOptionalValue(props.scaling, "1");
+  // Only configure the scaling transform if autoZoomToFit is
+  // true AND the scale factor provided is not 1 where 1
+  // implies no scaling
   if (props.autoZoomToFit && internalScale !== "1") {
     style["transform"] = "scale(" + internalScale + ")";
-    const scalingOrigin =
-      typeof props.scalingOrigin === "undefined"
-        ? "center top"
-        : props.scalingOrigin;
+    const scalingOrigin = getOptionalValue(props.scalingOrigin, "center top");
     style["transformOrigin"] = scalingOrigin;
   }
   return (

--- a/src/ui/widgets/DynamicPage/dynamicPage.tsx
+++ b/src/ui/widgets/DynamicPage/dynamicPage.tsx
@@ -66,7 +66,11 @@ export const DynamicPageComponent = (
         value={() => fileContext.removePage(props.location)}
       >
         <div style={style}>
-          <EmbeddedDisplay file={file} position={new RelativePosition()} />
+          <EmbeddedDisplay
+            file={file}
+            position={new RelativePosition()}
+            scalingOrigin={"0 0"}
+          />
           <div
             style={{
               position: "absolute",
@@ -107,7 +111,11 @@ export const DynamicPageComponent = (
         value={() => fileContext.removePage(props.location)}
       >
         <div style={style}>
-          <EmbeddedDisplay file={file} position={new RelativePosition()} />
+          <EmbeddedDisplay
+            file={file}
+            position={new RelativePosition()}
+            scalingOrigin={"0 0"}
+          />
         </div>
       </ExitFileContext.Provider>
     );

--- a/src/ui/widgets/EmbeddedDisplay/embeddedDisplay.tsx
+++ b/src/ui/widgets/EmbeddedDisplay/embeddedDisplay.tsx
@@ -38,7 +38,7 @@ export const EmbeddedDisplay = (
 ): JSX.Element => {
   const description = useOpiFile(props.file);
   const id = useId();
-  
+
   log.debug(description);
 
   // Check whether to override OPI autoZoomToFit

--- a/src/ui/widgets/utils.ts
+++ b/src/ui/widgets/utils.ts
@@ -63,3 +63,15 @@ export function trimFromString(value: string): number {
   }
   return num;
 }
+
+/**
+ * Return the value of an optional parameter that may be undefined.
+ * If it is undefined (i.e. not set) then return the default value
+ * (defValue) provided in the input.
+ * @param optionalParam parameter to get value from
+ * @param defValue default value if optionalParam is undefined
+ */
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export function getOptionalValue(optionalParam: any, defValue: any): any {
+  return typeof optionalParam === "undefined" ? defValue : optionalParam;
+}


### PR DESCRIPTION
The autoscaling to fit the window size does get a little complicated as there multiple use cases of this. The problem relates to what you define as the scale origin. This differs for different configurations. This PR fixes/maintains behaviour for the following cases:
- machine-status displays - these displays are central in the window and so their scaling origin is "center top". This will be the default for embedded displays unless specified.
- webcam displays - the original scaling issue referenced in #28 would be fixed with this re-work, but note it was already fixed in the machine-status app by changing the positions to be absolute instead of a percentage of the window.
- dynamicPage - layouts in cs-web-proto use dynamic pages to load in an OPI. These need to have a scaling origin of "0 0" to expand/contract into their designated area within the window.
- Linking Containers - OPIs which embed other OPIs are parsed as embeddedDisplays with embedded embeddedDisplays. We have to be careful here as if both the parent and child OPI has 'autoZoomToFit' as true then the scaling gets applied twice, once to the parent container and again to the child. I have created a special override parameter that can stop scaling of the child if the parent has already been scaled. Equally if the parent is not scaled but the child should be then we still need to expand the space in the parent container otherwise some of the child may be cut off when expanded.

I have tested these scaling fixes against all displays in cs-web-proto, machine-status display screens, machine-status web view and machine-status sdms. Behaviour is maintained in all machine-status screens and improved for cs-web-proto.