### PR TITLE
Export TabContainer widget for use

### DIFF
--- a/src/ui/widgets/index.ts
+++ b/src/ui/widgets/index.ts
@@ -26,6 +26,7 @@ export { SlideControl } from "./SlideControl/slideControl";
 export { Slideshow } from "./Slideshow/slideshow";
 export { Symbol } from "./Symbol/symbol";
 export { TabBar } from "./Tabs/tabs";
+export { TabContainer } from "./Tabs/tabContainer";
 export { DynamicTabs } from "./Tabs/dynamicTabs";
 export { XYPlot } from "./XYPlot/xyPlot";
 export { Webcam } from "./Webcam/webcam";


### PR DESCRIPTION
The TabContainer widget was not exported from the library and is required by cs-web-proto. I've also been through and checked that all other widgets have been exported.