### PR TITLE
Update to use the new `graphql-ws` websocket library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "utf-8-validate": "^5.0.10"
       },
       "devDependencies": {
-        "@apollo/client": "^3.3.19",
+        "@apollo/client": "^3.6.0",
         "@material-ui/core": "^4.9.9",
         "@rollup/plugin-commonjs": "^21.0.1",
         "@rollup/plugin-node-resolve": "^13.1.3",
@@ -36,6 +36,7 @@
         "eslint-plugin-import": "^2.20.0",
         "eslint-plugin-prettier": "^3.1.2",
         "eslint-plugin-unicorn": "^33.0.0",
+        "graphql-ws": "^5.9.1",
         "jest-canvas-mock": "^2.4.0",
         "loglevel": "^1.8.0",
         "prettier": "^2.2.1",
@@ -48,7 +49,6 @@
         "rollup-plugin-peer-deps-external": "^2.2.4",
         "rollup-plugin-postcss": "^4.0.2",
         "rollup-plugin-terser": "^7.0.2",
-        "subscriptions-transport-ws": "^0.9.16",
         "typescript": "^4.5.4",
         "xml-js": "^1.6.11"
       },
@@ -73,31 +73,40 @@
       }
     },
     "node_modules/@apollo/client": {
-      "version": "3.5.9",
-      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.5.9.tgz",
-      "integrity": "sha512-Qq3OE3GpyPG2fYXBzi1n4QXcKZ11c6jHdrXK2Kkn9SD+vUymSrllXsldqnKUK9tslxKqkKzNrkCXkLv7PxwfSQ==",
+      "version": "3.7.17",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.7.17.tgz",
+      "integrity": "sha512-0EErSHEtKPNl5wgWikHJbKFAzJ/k11O0WO2QyqZSHpdxdAnw7UWHY4YiLbHCFG7lhrD+NTQ3Z/H9Jn4rcikoJA==",
       "dev": true,
       "dependencies": {
-        "@graphql-typed-document-node/core": "^3.0.0",
-        "@wry/context": "^0.6.0",
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "@wry/context": "^0.7.0",
         "@wry/equality": "^0.5.0",
-        "@wry/trie": "^0.3.0",
-        "graphql-tag": "^2.12.3",
+        "@wry/trie": "^0.4.0",
+        "graphql-tag": "^2.12.6",
         "hoist-non-react-statics": "^3.3.2",
-        "optimism": "^0.16.1",
+        "optimism": "^0.16.2",
         "prop-types": "^15.7.2",
+        "response-iterator": "^0.2.6",
         "symbol-observable": "^4.0.0",
-        "ts-invariant": "^0.9.4",
+        "ts-invariant": "^0.10.3",
         "tslib": "^2.3.0",
-        "zen-observable-ts": "^1.2.0"
+        "zen-observable-ts": "^1.2.5"
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0",
-        "react": "^16.8.0 || ^17.0.0",
+        "graphql-ws": "^5.5.5",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
         "subscriptions-transport-ws": "^0.9.0 || ^0.11.0"
       },
       "peerDependenciesMeta": {
+        "graphql-ws": {
+          "optional": true
+        },
         "react": {
+          "optional": true
+        },
+        "react-dom": {
           "optional": true
         },
         "subscriptions-transport-ws": {
@@ -4417,9 +4426,9 @@
       }
     },
     "node_modules/@wry/context": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.6.1.tgz",
-      "integrity": "sha512-LOmVnY1iTU2D8tv4Xf6MVMZZ+juIJ87Kt/plMijjN20NMAXGmH4u8bS1t0uT74cZ5gwpocYueV58YwyI8y+GKw==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.7.3.tgz",
+      "integrity": "sha512-Nl8WTesHp89RF803Se9X3IiHjdmLBrIvPMaJkl+rKVJAYyPsz1TEUbu89943HpvujtSJgDUx9W4vZw3K1Mr3sA==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -4441,9 +4450,9 @@
       }
     },
     "node_modules/@wry/trie": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.3.1.tgz",
-      "integrity": "sha512-WwB53ikYudh9pIorgxrkHKrQZcCqNM/Q/bDzZBffEaGUKGuHrRb3zZUT9Sh2qw9yogC7SsdRmQ1ER0pqvd3bfw==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.4.3.tgz",
+      "integrity": "sha512-I6bHwH0fSf6RqQcnnXLJKhkSXG45MFral3GxPaY4uAl0LYDZM+YDVDAiU9bYwjTuysy1S0IeecWtmq1SZA3M1w==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
@@ -5503,7 +5512,9 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
       "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc=",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -11431,6 +11442,18 @@
         "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
+    "node_modules/graphql-ws": {
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.14.0.tgz",
+      "integrity": "sha512-itrUTQZP/TgswR4GSSYuwWUzrE/w5GhbwM2GX3ic2U7aw33jgEsayfIlvaj7/GcIvZgNMzsPTrE5hqPuFUiE5g==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "graphql": ">=0.11 <=16"
+      }
+    },
     "node_modules/grid-index": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/grid-index/-/grid-index-1.1.0.tgz",
@@ -13233,7 +13256,9 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
       "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/jest": {
       "version": "26.6.0",
@@ -15702,13 +15727,25 @@
       }
     },
     "node_modules/optimism": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.16.1.tgz",
-      "integrity": "sha512-64i+Uw3otrndfq5kaoGNoY7pvOhSsjFEN4bdEFh80MWVk/dbgJfMv7VFDeCT8LxNAlEVhQmdVEbfE7X2nWNIIg==",
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.16.2.tgz",
+      "integrity": "sha512-zWNbgWj+3vLEjZNIh/okkY2EUfX+vB9TJopzIZwT1xxaMqC5hRLLraePod4c5n4He08xuXNH+zhKFFCu390wiQ==",
       "dev": true,
       "dependencies": {
-        "@wry/context": "^0.6.0",
+        "@wry/context": "^0.7.0",
         "@wry/trie": "^0.3.0"
+      }
+    },
+    "node_modules/optimism/node_modules/@wry/trie": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.3.2.tgz",
+      "integrity": "sha512-yRTyhWSls2OY/pYLfwff867r8ekooZ4UI+/gxot5Wj8EFwSf2rG+n+Mo/6LoLQm1TKA4GRj2+LCpbfS937dClQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/optimize-css-assets-webpack-plugin": {
@@ -21787,6 +21824,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/response-iterator": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/response-iterator/-/response-iterator-0.2.6.tgz",
+      "integrity": "sha512-pVzEEzrsg23Sh053rmDUvLSkGXluZio0qu8VT6ukrYuvtjVfCbDZH9d6PGXb8HZfzdNZt8feXv/jvUzlhRgLnw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/ret": {
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
@@ -24527,6 +24573,8 @@
       "resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.9.19.tgz",
       "integrity": "sha512-dxdemxFFB0ppCLg10FTtRqH/31FNRL1y1BQv8209MK5I4CwALb7iihQg+7p65lFcIl8MHatINWBLOqpgU4Kyyw==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "backo2": "^1.0.2",
         "eventemitter3": "^3.1.0",
@@ -24542,13 +24590,17 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
       "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/subscriptions-transport-ws/node_modules/symbol-observable": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
       "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -25507,9 +25559,9 @@
       "dev": true
     },
     "node_modules/ts-invariant": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.9.4.tgz",
-      "integrity": "sha512-63jtX/ZSwnUNi/WhXjnK8kz4cHHpYS60AnmA6ixz17l7E12a5puCWFlNpkne5Rl0J8TBPVHpGjsj4fxs8ObVLQ==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.10.3.tgz",
+      "integrity": "sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.1.0"
@@ -28495,9 +28547,9 @@
       "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ=="
     },
     "node_modules/zen-observable-ts": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.2.3.tgz",
-      "integrity": "sha512-hc/TGiPkAWpByykMwDcem3SdUgA4We+0Qb36bItSuJC9xD0XVBZoFHYoadAomDSNf64CG8Ydj0Qb8Od8BUWz5g==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.2.5.tgz",
+      "integrity": "sha512-QZWQekv6iB72Naeake9hS1KxHlotfRpe+WGNbNx5/ta+R3DNjVO2bswf63gXlWDcs+EMd7XY8HfVQyP1X6T4Zg==",
       "dev": true,
       "dependencies": {
         "zen-observable": "0.8.15"
@@ -28515,23 +28567,24 @@
       }
     },
     "@apollo/client": {
-      "version": "3.5.9",
-      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.5.9.tgz",
-      "integrity": "sha512-Qq3OE3GpyPG2fYXBzi1n4QXcKZ11c6jHdrXK2Kkn9SD+vUymSrllXsldqnKUK9tslxKqkKzNrkCXkLv7PxwfSQ==",
+      "version": "3.7.17",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.7.17.tgz",
+      "integrity": "sha512-0EErSHEtKPNl5wgWikHJbKFAzJ/k11O0WO2QyqZSHpdxdAnw7UWHY4YiLbHCFG7lhrD+NTQ3Z/H9Jn4rcikoJA==",
       "dev": true,
       "requires": {
-        "@graphql-typed-document-node/core": "^3.0.0",
-        "@wry/context": "^0.6.0",
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "@wry/context": "^0.7.0",
         "@wry/equality": "^0.5.0",
-        "@wry/trie": "^0.3.0",
-        "graphql-tag": "^2.12.3",
+        "@wry/trie": "^0.4.0",
+        "graphql-tag": "^2.12.6",
         "hoist-non-react-statics": "^3.3.2",
-        "optimism": "^0.16.1",
+        "optimism": "^0.16.2",
         "prop-types": "^15.7.2",
+        "response-iterator": "^0.2.6",
         "symbol-observable": "^4.0.0",
-        "ts-invariant": "^0.9.4",
+        "ts-invariant": "^0.10.3",
         "tslib": "^2.3.0",
-        "zen-observable-ts": "^1.2.0"
+        "zen-observable-ts": "^1.2.5"
       }
     },
     "@babel/code-frame": {
@@ -31764,9 +31817,9 @@
       }
     },
     "@wry/context": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.6.1.tgz",
-      "integrity": "sha512-LOmVnY1iTU2D8tv4Xf6MVMZZ+juIJ87Kt/plMijjN20NMAXGmH4u8bS1t0uT74cZ5gwpocYueV58YwyI8y+GKw==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.7.3.tgz",
+      "integrity": "sha512-Nl8WTesHp89RF803Se9X3IiHjdmLBrIvPMaJkl+rKVJAYyPsz1TEUbu89943HpvujtSJgDUx9W4vZw3K1Mr3sA==",
       "dev": true,
       "requires": {
         "tslib": "^2.3.0"
@@ -31782,9 +31835,9 @@
       }
     },
     "@wry/trie": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.3.1.tgz",
-      "integrity": "sha512-WwB53ikYudh9pIorgxrkHKrQZcCqNM/Q/bDzZBffEaGUKGuHrRb3zZUT9Sh2qw9yogC7SsdRmQ1ER0pqvd3bfw==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.4.3.tgz",
+      "integrity": "sha512-I6bHwH0fSf6RqQcnnXLJKhkSXG45MFral3GxPaY4uAl0LYDZM+YDVDAiU9bYwjTuysy1S0IeecWtmq1SZA3M1w==",
       "dev": true,
       "requires": {
         "tslib": "^2.3.0"
@@ -32644,7 +32697,9 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
       "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc=",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "balanced-match": {
       "version": "1.0.2",
@@ -37416,6 +37471,13 @@
         "tslib": "^2.1.0"
       }
     },
+    "graphql-ws": {
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.14.0.tgz",
+      "integrity": "sha512-itrUTQZP/TgswR4GSSYuwWUzrE/w5GhbwM2GX3ic2U7aw33jgEsayfIlvaj7/GcIvZgNMzsPTrE5hqPuFUiE5g==",
+      "dev": true,
+      "requires": {}
+    },
     "grid-index": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/grid-index/-/grid-index-1.1.0.tgz",
@@ -38795,7 +38857,9 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
       "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "jest": {
       "version": "26.6.0",
@@ -40821,13 +40885,24 @@
       }
     },
     "optimism": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.16.1.tgz",
-      "integrity": "sha512-64i+Uw3otrndfq5kaoGNoY7pvOhSsjFEN4bdEFh80MWVk/dbgJfMv7VFDeCT8LxNAlEVhQmdVEbfE7X2nWNIIg==",
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.16.2.tgz",
+      "integrity": "sha512-zWNbgWj+3vLEjZNIh/okkY2EUfX+vB9TJopzIZwT1xxaMqC5hRLLraePod4c5n4He08xuXNH+zhKFFCu390wiQ==",
       "dev": true,
       "requires": {
-        "@wry/context": "^0.6.0",
+        "@wry/context": "^0.7.0",
         "@wry/trie": "^0.3.0"
+      },
+      "dependencies": {
+        "@wry/trie": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.3.2.tgz",
+          "integrity": "sha512-yRTyhWSls2OY/pYLfwff867r8ekooZ4UI+/gxot5Wj8EFwSf2rG+n+Mo/6LoLQm1TKA4GRj2+LCpbfS937dClQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        }
       }
     },
     "optimize-css-assets-webpack-plugin": {
@@ -45555,6 +45630,12 @@
         }
       }
     },
+    "response-iterator": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/response-iterator/-/response-iterator-0.2.6.tgz",
+      "integrity": "sha512-pVzEEzrsg23Sh053rmDUvLSkGXluZio0qu8VT6ukrYuvtjVfCbDZH9d6PGXb8HZfzdNZt8feXv/jvUzlhRgLnw==",
+      "dev": true
+    },
     "ret": {
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
@@ -47667,6 +47748,8 @@
       "resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.9.19.tgz",
       "integrity": "sha512-dxdemxFFB0ppCLg10FTtRqH/31FNRL1y1BQv8209MK5I4CwALb7iihQg+7p65lFcIl8MHatINWBLOqpgU4Kyyw==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
         "backo2": "^1.0.2",
         "eventemitter3": "^3.1.0",
@@ -47679,13 +47762,17 @@
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
           "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
-          "dev": true
+          "dev": true,
+          "optional": true,
+          "peer": true
         },
         "symbol-observable": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
           "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
-          "dev": true
+          "dev": true,
+          "optional": true,
+          "peer": true
         }
       }
     },
@@ -48456,9 +48543,9 @@
       "dev": true
     },
     "ts-invariant": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.9.4.tgz",
-      "integrity": "sha512-63jtX/ZSwnUNi/WhXjnK8kz4cHHpYS60AnmA6ixz17l7E12a5puCWFlNpkne5Rl0J8TBPVHpGjsj4fxs8ObVLQ==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.10.3.tgz",
+      "integrity": "sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==",
       "dev": true,
       "requires": {
         "tslib": "^2.1.0"
@@ -50913,9 +51000,9 @@
       "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ=="
     },
     "zen-observable-ts": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.2.3.tgz",
-      "integrity": "sha512-hc/TGiPkAWpByykMwDcem3SdUgA4We+0Qb36bItSuJC9xD0XVBZoFHYoadAomDSNf64CG8Ydj0Qb8Od8BUWz5g==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.2.5.tgz",
+      "integrity": "sha512-QZWQekv6iB72Naeake9hS1KxHlotfRpe+WGNbNx5/ta+R3DNjVO2bswf63gXlWDcs+EMd7XY8HfVQyP1X6T4Zg==",
       "dev": true,
       "requires": {
         "zen-observable": "0.8.15"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "utf-8-validate": "^5.0.10"
   },
   "devDependencies": {
-    "@apollo/client": "^3.3.19",
+    "@apollo/client": "^3.6.0",
     "@material-ui/core": "^4.9.9",
     "@rollup/plugin-commonjs": "^21.0.1",
     "@rollup/plugin-node-resolve": "^13.1.3",
@@ -45,6 +45,7 @@
     "eslint-plugin-import": "^2.20.0",
     "eslint-plugin-prettier": "^3.1.2",
     "eslint-plugin-unicorn": "^33.0.0",
+    "graphql-ws": "^5.9.1",
     "jest-canvas-mock": "^2.4.0",
     "loglevel": "^1.8.0",
     "prettier": "^2.2.1",
@@ -57,7 +58,6 @@
     "rollup-plugin-peer-deps-external": "^2.2.4",
     "rollup-plugin-postcss": "^4.0.2",
     "rollup-plugin-terser": "^7.0.2",
-    "subscriptions-transport-ws": "^0.9.16",
     "typescript": "^4.5.4",
     "xml-js": "^1.6.11"
   },

--- a/src/connection/coniql.ts
+++ b/src/connection/coniql.ts
@@ -6,7 +6,6 @@ import base64js from "base64-js";
 import { ApolloClient, ApolloLink, from } from "@apollo/client";
 import { RetryLink } from "apollo-link-retry";
 import { HttpLink } from "@apollo/client/link/http";
-import { WebSocketLink } from "@apollo/client/link/ws";
 import { onError } from "@apollo/client/link/error";
 import { InMemoryCache, NormalizedCacheObject } from "@apollo/client/cache";
 import {
@@ -24,10 +23,8 @@ import {
   DeviceQueriedCallback,
   nullDeviceCallback
 } from "./plugin";
-import {
-  OperationOptions,
-  SubscriptionClient
-} from "subscriptions-transport-ws";
+import { Client, createClient } from "graphql-ws";
+import { GraphQLWsLink } from "@apollo/client/link/subscriptions";
 import {
   DType,
   DTime,
@@ -275,7 +272,7 @@ export class ConiqlPlugin implements Connection {
   private onValueUpdate: ValueChangedCallback;
   private deviceQueried: DeviceQueriedCallback;
   private connected: boolean;
-  private wsClient: SubscriptionClient;
+  private wsClient: Client;
   private disconnected: string[] = [];
   private subscriptions: { [pvName: string]: ObservableSubscription };
 
@@ -295,52 +292,10 @@ export class ConiqlPlugin implements Connection {
         ]
       }
     });
-    let acknowledgementReceived = false;
-    this.wsClient = new SubscriptionClient(
-      `${this.wsProtocol}://${socket}/ws`,
-      {
-        reconnect: true,
-        connectionCallback: (error, result) => (acknowledgementReceived = true)
-      }
-    );
-    this.wsClient.use([
-      {
-        applyMiddleware(options: OperationOptions, next: any) {
-          if (!acknowledgementReceived) {
-            log.warn("Acknowledgement not received from server.");
-          }
-          next();
-        }
-      }
-    ]);
-    this.wsClient.onReconnecting((): void => {
-      log.info("Websocket client reconnected.");
-      for (const pvName of this.disconnected) {
-        this.subscribe(pvName);
-      }
-      this.disconnected = [];
-    });
-    this.wsClient.onDisconnected((): void => {
-      log.error("Websocket client disconnected.");
-      acknowledgementReceived = false;
-      for (const pvName of Object.keys(this.subscriptions)) {
-        if (
-          this.subscriptions.hasOwnProperty(pvName) &&
-          this.subscriptions[pvName]
-        ) {
-          this.subscriptions[pvName].unsubscribe();
-          delete this.subscriptions[pvName];
-          this.disconnected.push(pvName);
-        } else {
-          log.error(`Attempt to unsubscribe from ${pvName} failed`);
-        }
-        this.onConnectionUpdate(pvName, {
-          isConnected: false,
-          isReadonly: true
-        });
-      }
-      this.wsClient.unsubscribeAll();
-      this.wsClient.close();
+    this.wsClient = createClient({
+      url: `${this.wsProtocol}://${socket}/ws`,
+      retryAttempts: Infinity,
+      shouldRetry: () => true
     });
     const link = this.createLink(socket);
     this.client = new ApolloClient({ link, cache });
@@ -352,7 +307,7 @@ export class ConiqlPlugin implements Connection {
   }
 
   private createLink(socket: string): ApolloLink {
-    const wsLink = new WebSocketLink(this.wsClient);
+    const wsLink = new GraphQLWsLink(this.wsClient);
     const errorLink = onError(({ graphQLErrors, networkError }) => {
       if (graphQLErrors) {
         log.error("GraphQL errors:");


### PR DESCRIPTION
The websocket protocol library `subscription-transport-ws` has been deprecated and so users should move to the `graphql-ws` library (ref: https://www.npmjs.com/package/subscriptions-transport-ws). In this PR I have:
- changed the websocket client to use the new `graphql-ws` library to create the client,
- used the compatible `GraphQLWsLink`,
- removed a lot of the logic that we put in to handle re-connections to Coniql that are no longer needed with the new client,
- updated dependencies as required.

I have tested this against the `machine-status` application as well as a performance page updating 200 PVs at 10 Hz. I have tested different scenarios such as refreshing the browser page and disconnecting + reconnecting Coniql while the page is open. In these cases I did not see a memory leak in Coniql (which had been seen in https://github.com/DiamondLightSource/coniql/issues/35) and I saw that connections were re-established after Coniql was disconnected for a long period of time. 