### PR TITLE
Update bytemonitor widget

### DIFF
--- a/src/ui/widgets/ByteMonitor/byteMonitor.test.tsx
+++ b/src/ui/widgets/ByteMonitor/byteMonitor.test.tsx
@@ -26,11 +26,11 @@ describe("<ByteMonitorComponent />", (): void => {
     const bits = byteMonitor.children as Array<ReactTestRendererJSON>;
     expect(bits.length).toEqual(16);
 
-    expect(bits[0].props.style.marginRight).toEqual("-3px");
-    expect(bits[1].props.style.borderWidth).toEqual(0);
+    expect(bits[0].props.style.marginRight).toEqual("-2px");
+    expect(bits[1].props.style.borderWidth).toEqual("2px");
     expect(bits[5].props.style.backgroundColor).toEqual("rgba(0,100,0,255)");
-    expect(bits[10].props.style.boxShadow).toEqual(
-      "inset 0.0625px 0.0625px 0.1px rgba(255,255,255,.5), 1px 1px white, -1px -1px darkgray"
+    expect(bits[10].props.style.backgroundImage).toEqual(
+      "radial-gradient(circle at top left, white, rgba(0,100,0,255)), radial-gradient(circle at top left, black,white)"
     );
     expect(bits[15].props.style.borderRadius).toEqual("50%");
   });
@@ -67,31 +67,8 @@ describe("<ByteMonitorComponent />", (): void => {
 });
 
 describe("ByteMonitor functions", (): void => {
-  test("recalculateDimensions() for 3d bits", (): void => {
-    const [dx, dy, border] = recalculateDimensions(
-      4,
-      40,
-      40,
-      2,
-      true,
-      false,
-      true
-    );
-    expect(dx).toEqual(7);
-    expect(dy).toEqual(38);
-    expect(border).toEqual(2);
-  });
-
-  test("recalculateDimensions() for 2d bits", (): void => {
-    const [dx, dy, border] = recalculateDimensions(
-      4,
-      40,
-      40,
-      2,
-      true,
-      false,
-      false
-    );
+  test("recalculateDimensions() for bits", (): void => {
+    const [dx, dy, border] = recalculateDimensions(4, 40, 40, 2, true, false);
     expect(dx).toEqual(9.5);
     expect(dy).toEqual(38);
     expect(border).toEqual(2);

--- a/src/ui/widgets/ByteMonitor/byteMonitor.tsx
+++ b/src/ui/widgets/ByteMonitor/byteMonitor.tsx
@@ -75,8 +75,7 @@ export const ByteMonitorComponent = (
       height,
       border,
       horizontal,
-      squareLed,
-      effect3d
+      squareLed
     );
     const ledArray: Array<JSX.Element> = [];
     dataValues.forEach((data: number, idx: number) => {
@@ -95,29 +94,42 @@ export const ByteMonitorComponent = (
         : offColor?.toString();
       // Set border color and thickness
       style["borderColor"] = ledBorderColor.toString();
-      // If 3D, no border
-      style["borderWidth"] = effect3d ? 0 : `${borderWidth}px`;
+      style["borderWidth"] = `${borderWidth}px`;
       // Set shape as square or circular
       if (squareLed) {
-        style.width = `${bitWidth}px`;
-        style.height = `${bitHeight}px`;
+        style.width = `${bitWidth + borderWidth}px`;
+        style.height = `${bitHeight + borderWidth}px`;
       } else {
+        // If 3d, border width is slightly narrower
         // If circular led, width and height are the same
-        style.width = horizontal ? `${bitWidth}px` : `${bitHeight}px`;
+        style.width = horizontal
+          ? `${bitWidth + borderWidth}px`
+          : `${bitHeight + borderWidth}px`;
         style.height = style.width;
         style["borderRadius"] = "50%";
       }
-      // Add shadow for 3D effect
+      // Add 3D effect
       if (effect3d) {
-        style["margin"] = "1px"; // Margin to ensure LEDs don't overlap
-        style["boxShadow"] = `inset ${bitWidth / 4}px ${bitWidth / 4}px ${
-          bitWidth * 0.4
-        }px rgba(255,255,255,.5), 1px 1px white, -1px -1px darkgray`;
+        // For ellipse, border is different in 3D. For square it is the same
+        // but the LED has a shadow
+        style[
+          "backgroundImage"
+        ] = `radial-gradient(circle at top left, white, ${
+          data ? onColor?.toString() : offColor?.toString()
+        })`;
+        if (!squareLed) {
+          style["borderColor"] = "transparent";
+          style["backgroundImage"] +=
+            ", radial-gradient(circle at top left, black,white)";
+          style["backgroundOrigin"] = "border-box";
+          style["backgroundClip"] = "padding-box, border-box";
+        }
       }
       const className = classes.Bit;
       const bitDiv = (
         <div key={`bit${idx}`} className={className} style={style} />
       );
+
       ledArray.push(bitDiv);
     });
 
@@ -149,8 +161,7 @@ export function recalculateDimensions(
   height: number,
   ledBorder: number,
   horizontal: boolean,
-  squareLed: boolean,
-  effect3d: boolean
+  squareLed: boolean
 ): number[] {
   width = width - 2;
   height = height - 2;
@@ -158,7 +169,6 @@ export function recalculateDimensions(
   const size = horizontal ? width : height;
   // Calculate how wide led can be if we use existing bit Size
   let bitSize = size / numBits;
-  if (effect3d) bitSize = (size - ledBorder * (numBits + 1)) / numBits;
   // If bitSize < 1 only show border not led
   if (!squareLed) {
     // Check that bitSize fits in other axis if circular led


### PR DESCRIPTION
Updated the widget so that the sizing of LEDs now more accurately replicates CSStudio sizing. I have also improved the 3D effect appearance and updated tests.
This is their appearance now in cs-web-lib
![Bytemonitor in cs-web-lib](https://github.com/dls-controls/cs-web-lib/assets/91315856/ec4b02ca-68fb-4e47-8633-98f6a922d4dc)
![Bytemonitor in cs-web-lib](https://github.com/dls-controls/cs-web-lib/assets/91315856/10e154f9-6e1f-43a1-befa-bb5e21608886)
versus how the same widgets look in CSStudio
![Bytemonitor in CSStudio](https://github.com/dls-controls/cs-web-lib/assets/91315856/8895861e-0818-4cc8-8ddc-9d946eca0367)
![Bytemonitor in CSStudio](https://github.com/dls-controls/cs-web-lib/assets/91315856/6b284561-de28-4eb4-a14c-161eaccc5ce8)
