### PR TITLE
Fix Line widget Issue #47

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "plotly.js-basic-dist": "^2.20.0",
         "react-plotly.js": "^2.6.0",
         "redux": "^4.1.2",
-        "utf-8-validate": "^5.0.10"
+        "utf-8-validate": "^5.0.10",
+        "uuid": "^9.0.1"
       },
       "devDependencies": {
         "@apollo/client": "^3.6.0",
@@ -30,6 +31,7 @@
         "@types/node": "^17.0.18",
         "@types/react-plotly.js": "^2.5.2",
         "@types/react-test-renderer": "^17.0.1",
+        "@types/uuid": "^9.0.8",
         "base64-js": "^1.3.1",
         "clipboard-copy": "^4.0.1",
         "eslint-config-prettier": "^8.3.0",
@@ -4029,6 +4031,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
+      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
+      "dev": true
     },
     "node_modules/@types/webpack": {
       "version": "4.41.32",
@@ -15281,6 +15289,16 @@
         "which": "^2.0.2"
       }
     },
+    "node_modules/node-notifier/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "optional": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.2.tgz",
@@ -23756,6 +23774,15 @@
         "ms": "^2.1.1"
       }
     },
+    "node_modules/sockjs/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/sort-keys": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
@@ -26152,10 +26179,13 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -31496,6 +31526,12 @@
           "dev": true
         }
       }
+    },
+    "@types/uuid": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
+      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
+      "dev": true
     },
     "@types/webpack": {
       "version": "4.41.32",
@@ -40546,6 +40582,15 @@
         "shellwords": "^0.1.1",
         "uuid": "^8.3.0",
         "which": "^2.0.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "dev": true,
+          "optional": true
+        }
       }
     },
     "node-releases": {
@@ -47056,6 +47101,14 @@
         "faye-websocket": "^0.11.3",
         "uuid": "^8.3.2",
         "websocket-driver": "^0.7.4"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "dev": true
+        }
       }
     },
     "sockjs-client": {
@@ -49027,10 +49080,9 @@
       }
     },
     "uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "plotly.js-basic-dist": "^2.20.0",
     "react-plotly.js": "^2.6.0",
     "redux": "^4.1.2",
-    "utf-8-validate": "^5.0.10"
+    "utf-8-validate": "^5.0.10",
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@apollo/client": "^3.6.0",
@@ -39,6 +40,7 @@
     "@types/node": "^17.0.18",
     "@types/react-plotly.js": "^2.5.2",
     "@types/react-test-renderer": "^17.0.1",
+    "@types/uuid": "^9.0.8",
     "base64-js": "^1.3.1",
     "clipboard-copy": "^4.0.1",
     "eslint-config-prettier": "^8.3.0",

--- a/src/ui/widgets/EmbeddedDisplay/opiParser.ts
+++ b/src/ui/widgets/EmbeddedDisplay/opiParser.ts
@@ -660,7 +660,8 @@ export const OPI_SIMPLE_PARSERS: ParserDict = {
   cornerWidth: ["corner_width", opiParseString],
   cornerHeight: ["corner_height", opiParseString],
   arrows: ["arrows", opiParseNumber],
-  arrowLength: ["arrow_length", opiParseNumber]
+  arrowLength: ["arrow_length", opiParseNumber],
+  fillArrow: ["fill_arrow", opiParseBoolean]
 };
 
 /**

--- a/src/ui/widgets/EmbeddedDisplay/opiParser.ts
+++ b/src/ui/widgets/EmbeddedDisplay/opiParser.ts
@@ -658,7 +658,9 @@ export const OPI_SIMPLE_PARSERS: ParserDict = {
   effect3d: ["effect_3d", opiParseBoolean],
   showLed: ["show_led", opiParseBoolean],
   cornerWidth: ["corner_width", opiParseString],
-  cornerHeight: ["corner_height", opiParseString]
+  cornerHeight: ["corner_height", opiParseString],
+  arrows: ["arrows", opiParseNumber],
+  arrowLength: ["arrow_length", opiParseNumber]
 };
 
 /**

--- a/src/ui/widgets/Line/__snapshots__/line.test.tsx.snap
+++ b/src/ui/widgets/Line/__snapshots__/line.test.tsx.snap
@@ -2,8 +2,18 @@
 
 exports[`<LineComponent /> matches snapshot 1`] = `
 <DocumentFragment>
-  <div
-    style="background-color: rgb(0, 255, 255); width: 50px; height: 4px; border-radius: 0; transform: rotate(45deg);"
-  />
+  <svg
+    viewBox="0 0 20 15"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <polyline
+      fill="none"
+      overflow="visible"
+      points="2,20 6,30 15,4 "
+      stroke="rgba(0,255,255,255)"
+      stroke-width="4"
+      transform="rotation(45,0,0)"
+    />
+  </svg>
 </DocumentFragment>
 `;

--- a/src/ui/widgets/Line/__snapshots__/line.test.tsx.snap
+++ b/src/ui/widgets/Line/__snapshots__/line.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`<LineComponent /> matches snapshot 1`] = `
 <DocumentFragment>
   <svg
+    overflow="visible"
     viewBox="0 0 20 15"
     xmlns="http://www.w3.org/2000/svg"
   >

--- a/src/ui/widgets/Line/line.test.tsx
+++ b/src/ui/widgets/Line/line.test.tsx
@@ -49,11 +49,9 @@ describe("<LineComponent />", (): void => {
     };
 
     const svg = LineRenderer(lineProps);
-    console.log(svg);
     expect(svg.props.viewBox).toEqual("0 0 20 25");
 
     const lines = svg.children as Array<ReactTestRendererJSON>;
-    console.log(lines);
 
     expect(lines[0].props.stroke).toEqual("rgba(0,255,255,255)");
     expect(lines[0].props.strokeWidth).toEqual(1);

--- a/src/ui/widgets/Line/line.test.tsx
+++ b/src/ui/widgets/Line/line.test.tsx
@@ -49,9 +49,11 @@ describe("<LineComponent />", (): void => {
     };
 
     const svg = LineRenderer(lineProps);
+    console.log(svg);
     expect(svg.props.viewBox).toEqual("0 0 20 25");
 
     const lines = svg.children as Array<ReactTestRendererJSON>;
+    console.log(lines);
 
     expect(lines[0].props.stroke).toEqual("rgba(0,255,255,255)");
     expect(lines[0].props.strokeWidth).toEqual(1);
@@ -74,18 +76,28 @@ describe("<LineComponent />", (): void => {
           { x: 25, y: 10 },
           { x: 4, y: 15 }
         ]
-      }
+      },
+      arrows: 3,
+      arrowLength: 10
     };
 
     const svg = LineRenderer(lineProps);
     expect(svg.props.viewBox).toEqual("0 0 30 20");
 
     const lines = svg.children as Array<ReactTestRendererJSON>;
+    const marker = lines[0].children as Array<ReactTestRendererJSON>;
 
-    expect(lines[0].props.stroke).toEqual("rgba(0,0,0,0)");
-    expect(lines[0].props.strokeWidth).toEqual(15);
-    expect(lines[0].props.transform).toEqual("rotation(45,0,0)");
-    expect(lines[0].props.points).toEqual("16,4 25,10 4,15 ");
+    // Check arrowhead definitions were created
+    expect(marker[0].props.markerWidth).toEqual("10");
+    expect(marker[0].props.markerHeight).toEqual("10");
+    expect(marker[0].props.orient).toEqual("auto-start-reverse");
+
+    expect(lines[1].props).toHaveProperty("markerStart");
+    expect(lines[1].props).toHaveProperty("markerEnd");
+    expect(lines[1].props.stroke).toEqual("rgba(0,0,0,0)");
+    expect(lines[1].props.strokeWidth).toEqual(15);
+    expect(lines[1].props.transform).toEqual("rotation(45,0,0)");
+    expect(lines[1].props.points).toEqual("16,4 25,10 4,15 ");
   });
 
   test("line component not created if no points to plot", (): void => {

--- a/src/ui/widgets/Line/line.test.tsx
+++ b/src/ui/widgets/Line/line.test.tsx
@@ -59,7 +59,7 @@ describe("<LineComponent />", (): void => {
     expect(lines[0].props.points).toEqual("1,10 15,20 4,15 ");
   });
 
-  test("props override default properties", (): void => {
+  test("props override default properties, no arrows", (): void => {
     const lineProps = {
       width: 30,
       height: 20,
@@ -75,8 +75,39 @@ describe("<LineComponent />", (): void => {
           { x: 4, y: 15 }
         ]
       },
+      arrows: 0
+    };
+
+    const svg = LineRenderer(lineProps);
+    expect(svg.props.viewBox).toEqual("0 0 30 20");
+
+    const lines = svg.children as Array<ReactTestRendererJSON>;
+
+    expect(lines[0].props.stroke).toEqual("rgba(0,0,0,0)");
+    expect(lines[0].props.strokeWidth).toEqual(15);
+    expect(lines[0].props.transform).toEqual("rotation(45,0,0)");
+    expect(lines[0].props.points).toEqual("16,4 25,10 4,15 ");
+  });
+
+  test("line with filled arrowhead", (): void => {
+    const lineProps = {
+      width: 30,
+      height: 20,
+      lineWidth: 15,
+      backgroundColor: Color.fromRgba(0, 254, 250),
+      transparent: true,
+      rotationAngle: 45,
+      visible: true,
+      points: {
+        values: [
+          { x: 16, y: 5 },
+          { x: 26, y: 10 },
+          { x: 6, y: 15 }
+        ]
+      },
       arrows: 3,
-      arrowLength: 10
+      arrowLength: 2,
+      fillArrow: true
     };
 
     const svg = LineRenderer(lineProps);
@@ -86,16 +117,52 @@ describe("<LineComponent />", (): void => {
     const marker = lines[0].children as Array<ReactTestRendererJSON>;
 
     // Check arrowhead definitions were created
-    expect(marker[0].props.markerWidth).toEqual("10");
-    expect(marker[0].props.markerHeight).toEqual("10");
+    expect(marker[0].props.markerWidth).toEqual("2");
+    expect(marker[0].props.markerHeight).toEqual("2");
     expect(marker[0].props.orient).toEqual("auto-start-reverse");
+    expect(marker[0].props.markerUnits).toEqual("userSpaceOnUse");
 
     expect(lines[1].props).toHaveProperty("markerStart");
     expect(lines[1].props).toHaveProperty("markerEnd");
+    expect(lines[1].props.points).toEqual("18,6 26,10 8,15 ");
+  });
+
+  test("line with unfilled arrowhead", (): void => {
+    const lineProps = {
+      width: 30,
+      height: 20,
+      lineWidth: 2,
+      backgroundColor: Color.fromRgba(0, 254, 250),
+      transparent: true,
+      rotationAngle: 45,
+      visible: true,
+      points: {
+        values: [
+          { x: 40, y: 10 },
+          { x: 40, y: 20 },
+          { x: 20, y: 20 }
+        ]
+      },
+      arrows: 1,
+      arrowLength: 2,
+      fillArrow: false
+    };
+
+    const svg = LineRenderer(lineProps);
+    expect(svg.props.viewBox).toEqual("0 0 30 20");
+
+    const lines = svg.children as Array<ReactTestRendererJSON>;
+    const marker = lines[0].children as Array<ReactTestRendererJSON>;
+
+    // Check arrowhead definitions were created
+    expect(marker[0].props.markerWidth).toEqual("1");
+    expect(marker[0].props.markerHeight).toEqual("1");
+    expect(marker[0].props.orient).toEqual("auto-start-reverse");
+    expect(marker[0].props.markerUnits).toEqual("strokeWidth");
+
+    expect(lines[1].props).toHaveProperty("markerStart");
     expect(lines[1].props.stroke).toEqual("rgba(0,0,0,0)");
-    expect(lines[1].props.strokeWidth).toEqual(15);
-    expect(lines[1].props.transform).toEqual("rotation(45,0,0)");
-    expect(lines[1].props.points).toEqual("16,4 25,10 4,15 ");
+    expect(lines[1].props.points).toEqual("40,10 40,20 20,20 ");
   });
 
   test("line component not created if no points to plot", (): void => {

--- a/src/ui/widgets/Line/line.tsx
+++ b/src/ui/widgets/Line/line.tsx
@@ -6,19 +6,22 @@ import {
   FloatPropOpt,
   ColorPropOpt,
   BoolPropOpt,
-  FloatProp
+  FloatProp,
+  PointsPropOpt
 } from "../propTypes";
 import { registerWidget } from "../register";
-import { ShapeComponent } from "../Shape/shape";
 import { Color } from "../../../types/color";
+import { Point } from "../../../types/points";
 
 const LineProps = {
   width: FloatProp,
+  height: FloatProp,
   lineWidth: FloatPropOpt,
   backgroundColor: ColorPropOpt,
   visible: BoolPropOpt,
   transparent: BoolPropOpt,
-  rotationAngle: FloatPropOpt
+  rotationAngle: FloatPropOpt,
+  points: PointsPropOpt
 };
 
 export type LineComponentProps = InferWidgetProps<typeof LineProps> &
@@ -31,27 +34,40 @@ export const LineComponent = (props: LineComponentProps): JSX.Element => {
     backgroundColor,
     rotationAngle = 0,
     width,
-    lineWidth = 1
+    height,
+    lineWidth = 1,
+    points
   } = props;
 
-  const styleProps = {
-    backgroundColor: transparent ? Color.TRANSPARENT : backgroundColor,
-    visible
-  };
+  const transform = `rotation(${rotationAngle},0,0)`;
 
-  const shapeProps = {
-    shapeWidth: `${width}px`,
-    shapeHeight: `${lineWidth}px`
-  };
-
-  const transform = `rotate(${rotationAngle}deg)`;
-
-  return (
-    <ShapeComponent
-      {...{ ...shapeProps, ...styleProps }}
-      shapeTransform={transform}
-    />
-  );
+  let coordinates = "";
+  if (points !== undefined && visible) {
+    points.values.forEach((point: Point) => {
+      coordinates += `${point.x},${point.y} `;
+    });
+    return (
+      <svg
+        viewBox={`0 0 ${width} ${height}`}
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <polyline
+          overflow={"visible"}
+          stroke={
+            transparent
+              ? Color.TRANSPARENT.toString()
+              : backgroundColor?.toString()
+          }
+          fill={"none"}
+          strokeWidth={lineWidth}
+          transform={transform}
+          points={coordinates}
+        />
+      </svg>
+    );
+  } else {
+    return <></>;
+  }
 };
 
 const LineWidgetProps = {

--- a/src/ui/widgets/Line/line.tsx
+++ b/src/ui/widgets/Line/line.tsx
@@ -49,7 +49,6 @@ export const LineComponent = (props: LineComponentProps): JSX.Element => {
   const transform = `rotation(${rotationAngle},0,0)`;
 
   // Each marker definition needs a unique ID or colours overlap
-  // Get random decimal number, take decimal part and truncate
   const uid = uuidv4();
 
   // Create a marker if arrows set


### PR DESCRIPTION
Fixed the functionality of the line widget so the behaviour more closely matches that of CSS/Phoebus

- Line is an svg `polyline` with multiple points of x,y coordinates joined by lines
- Arrowheads can be added to either or both ends of the line
- Tests updated, along with snapshot