### PR TITLE
Change EmbeddedDisplay overflow mode to "auto"

### DIFF
--- a/src/ui/widgets/EmbeddedDisplay/embeddedDisplay.tsx
+++ b/src/ui/widgets/EmbeddedDisplay/embeddedDisplay.tsx
@@ -106,7 +106,7 @@ export const EmbeddedDisplay = (
         description.backgroundColor ?? new Color("rgb(200,200,200"),
       border:
         props.border ?? new Border(BorderStyle.Line, new Color("white"), 0),
-      overflow: props.scroll ? "scroll" : "hidden",
+      overflow: props.scroll ? "auto" : "hidden",
       children: [description],
       scaling: scaleFactor,
       autoZoomToFit: applyAutoZoomToFit,


### PR DESCRIPTION
Changed the overflow behaviour for EmbeddedDisplay to "auto". This means that scrollbars appear when necessary, but do not appear when there is no overflow. 

This was after reported issues in Google Chrome of seeing double scrollbars even when application was in full-screen mode. Firefox hides scrollbars when not needed, so there is no difference in behaviour for this browser.