### PR TITLE
Allow files from URLs starting "http" to be fetched and parsed

### DIFF
--- a/src/ui/widgets/EmbeddedDisplay/opiParser.ts
+++ b/src/ui/widgets/EmbeddedDisplay/opiParser.ts
@@ -716,7 +716,7 @@ function opiPatchPaths(
 ): void {
   log.debug(`opiPatchPaths ${parentDir}`);
   // file: OpiFile type
-  if (widgetDescription["file"] && parentDir) {
+  if (widgetDescription["file"] && parentDir && !widgetDescription["file"].path.startsWith("http")) {
     widgetDescription["file"].path = normalisePath(
       widgetDescription["file"].path,
       parentDir

--- a/src/ui/widgets/EmbeddedDisplay/opiParser.ts
+++ b/src/ui/widgets/EmbeddedDisplay/opiParser.ts
@@ -716,7 +716,11 @@ function opiPatchPaths(
 ): void {
   log.debug(`opiPatchPaths ${parentDir}`);
   // file: OpiFile type
-  if (widgetDescription["file"] && parentDir && !widgetDescription["file"].path.startsWith("http")) {
+  if (
+    widgetDescription["file"] &&
+    parentDir &&
+    !widgetDescription["file"].path.startsWith("http")
+  ) {
     widgetDescription["file"].path = normalisePath(
       widgetDescription["file"].path,
       parentDir


### PR DESCRIPTION
This change allows us to read files from URLs over HTTP by not calling the `normalisePath` function (which adds the directory root to the start of the path).