### PR TITLE
Improve BOB parsing and precision handling

### DIFF
--- a/src/ui/widgets/EmbeddedDisplay/bobParser.test.ts
+++ b/src/ui/widgets/EmbeddedDisplay/bobParser.test.ts
@@ -91,4 +91,76 @@ describe("opi widget parser", (): void => {
     // Is this correct?
     expect(display.x).toEqual(undefined);
   });
+
+  const readbackDefaults = `
+  <display version="2.0.0">
+    <x>0</x>
+    <y>0</y>
+    <width>300</width>
+    <height>300</height>
+    <widget type="textupdate" version="2.0.0">
+      <name>Text Update</name>
+      <pv_name>abc</pv_name>
+      <x>12</x>
+      <y>62</y>
+      <width>140</width>
+      <height>50</height>
+      <border_alarm_sensitive>false</border_alarm_sensitive>
+    </widget>
+  </display>`;
+  it("parses defaults", (): void => {
+    const widget = parseBob(readbackDefaults, "xxx", PREFIX)
+      .children?.[0] as WidgetDescription;
+    expect(widget.precisionFromPv).toEqual(true);
+    expect(widget.showUnits).toEqual(true);
+  });
+
+  const readbackPrecisionUnits = `
+  <display version="2.0.0">
+    <x>0</x>
+    <y>0</y>
+    <width>300</width>
+    <height>300</height>
+    <widget type="textupdate" version="2.0.0">
+      <name>Text Update</name>
+      <pv_name>abc</pv_name>
+      <x>12</x>
+      <y>62</y>
+      <width>140</width>
+      <height>50</height>
+      <border_alarm_sensitive>false</border_alarm_sensitive>
+      <precision>2</precision>
+      <show_units>false</show_units>
+    </widget>
+  </display>`;
+  it("parses precision and units", (): void => {
+    const widget = parseBob(readbackPrecisionUnits, "xxx", PREFIX)
+      .children?.[0] as WidgetDescription;
+    expect(widget.precisionFromPv).toEqual(undefined);
+    expect(widget.precision).toEqual(2);
+    expect(widget.showUnits).toEqual(false);
+  });
+
+  const readbackStringFormat = `
+  <display version="2.0.0">
+    <x>0</x>
+    <y>0</y>
+    <width>300</width>
+    <height>300</height>
+    <widget type="textupdate" version="2.0.0">
+      <name>Text Update</name>
+      <pv_name>abc</pv_name>
+      <x>12</x>
+      <y>62</y>
+      <width>140</width>
+      <height>50</height>
+      <border_alarm_sensitive>false</border_alarm_sensitive>
+      <format>6</format>
+    </widget>
+  </display>`;
+  it("parses string format", (): void => {
+    const widget = parseBob(readbackStringFormat, "xxx", PREFIX)
+      .children?.[0] as WidgetDescription;
+    expect(widget.formatType).toEqual("string");
+  });
 });

--- a/src/ui/widgets/EmbeddedDisplay/bobParser.ts
+++ b/src/ui/widgets/EmbeddedDisplay/bobParser.ts
@@ -106,6 +106,16 @@ function bobParsePosition(props: any): Position {
   );
 }
 
+function bobParseFormatType(jsonProp: ElementCompact): string {
+  const formats: { [key: number]: string } = {
+    0: "default",
+    1: "decimal",
+    2: "exponential",
+    6: "string"
+  };
+  return formats[bobParseNumber(jsonProp) ?? 0];
+}
+
 export function bobParseFont(jsonProp: ElementCompact): Font {
   const opiStyles: { [key: number]: FontStyle } = {
     0: FontStyle.Regular,
@@ -248,7 +258,8 @@ export function parseBob(
     imageFile: ["file", opiParseString],
     points: ["points", bobParsePoints],
     resize: ["resize", bobParseResizing],
-    squareLed: ["square", opiParseBoolean]
+    squareLed: ["square", opiParseBoolean],
+    formatType: ["format", bobParseFormatType]
   };
 
   const complexParsers = {

--- a/src/ui/widgets/EmbeddedDisplay/opiParser.test.ts
+++ b/src/ui/widgets/EmbeddedDisplay/opiParser.test.ts
@@ -271,7 +271,7 @@ describe("opi widget parser", (): void => {
     <width>20</width>
     <widget typeId="org.csstudio.opibuilder.widgets.TextInput" version="2.0.0">
       <text />
-      <show_units>not-a-bool</show_units>
+      <enabled>not-a-bool</enabled>
     </widget>
   </display>`;
   it("doesn't parse an invalid bool", (): void => {
@@ -279,7 +279,7 @@ describe("opi widget parser", (): void => {
     log.setLevel("error");
     const widget = parseOpi(invalidBool, "ca", PREFIX)
       .children?.[0] as WidgetDescription;
-    expect(widget.showUnits).toBeUndefined();
+    expect(widget.enabled).toBeUndefined();
     log.setLevel("info");
   });
   const xygraphString = `

--- a/src/ui/widgets/EmbeddedDisplay/parser.ts
+++ b/src/ui/widgets/EmbeddedDisplay/parser.ts
@@ -151,5 +151,17 @@ export function parseWidget(
       filepath
     );
   });
+
+  // Default to true if precision is not defined.
+  // Applicable to BOB files.
+  if (widgetDescription.precision === undefined) {
+    widgetDescription.precisionFromPv = true;
+  }
+  // Default to true if showUnits is not defined.
+  // Applicable to BOB files.
+  if (widgetDescription.showUnits === undefined) {
+    widgetDescription.showUnits = true;
+  }
+
   return widgetDescription;
 }

--- a/src/ui/widgets/Readback/readback.tsx
+++ b/src/ui/widgets/Readback/readback.tsx
@@ -89,6 +89,15 @@ export const ReadbackComponent = (
       } else {
         displayedValue = DType.coerceString(value);
       }
+    } else if (value.getArrayValue() !== undefined && prec !== undefined) {
+      displayedValue = "";
+      const array = Array.prototype.slice.call(value.getArrayValue());
+      for (let i = 0; i < array.length; i++) {
+        displayedValue = displayedValue.concat(array[i].toFixed(prec));
+        if (i < array.length - 1) {
+          displayedValue = displayedValue.concat(", ");
+        }
+      }
     } else {
       displayedValue = DType.coerceString(value);
     }


### PR DESCRIPTION
This PR addresses 2 points:
1. By default Phoebus sets the precision to `-1` (to signal `from PV`) and show units to `true`. In this case Phoebus will not write these properties to the BOB file and they will not exist. If these properties are missing then Phoebus assumes the above. These properties are only written to the the BOB file when the precision is set to something other than `-1` or show units is `false`. The lib parser needs updating to reflect the case when these properties are missing so that the behaviour resembles that of Phoebus. In addition the `format` enumerations in Phoebus are different so these need to be parsed separately.
2. Elements in an array (from a waveform PV) do not respect the precision rules. Logic has been added to format array elements to the specified precision.