### PR TITLE
Handle BOB file default word-wrap property

### DIFF
--- a/src/ui/widgets/EmbeddedDisplay/bobParser.test.ts
+++ b/src/ui/widgets/EmbeddedDisplay/bobParser.test.ts
@@ -37,6 +37,7 @@ describe("opi widget parser", (): void => {
     <x>10</x>
     <y>20</y>
     <not_a_property>hello</not_a_property>
+    <wrap_words>false</wrap_words>
   </widget>
   </display>`;
 
@@ -56,6 +57,7 @@ describe("opi widget parser", (): void => {
     expect(widget.foregroundColor).toEqual(Color.RED);
     // Unrecognised property not passed on.
     expect(widget.not_a_property).toEqual(undefined);
+    expect(widget.wrapWords).toEqual(false);
   });
 
   const readbackString = `
@@ -113,6 +115,7 @@ describe("opi widget parser", (): void => {
       .children?.[0] as WidgetDescription;
     expect(widget.precisionFromPv).toEqual(true);
     expect(widget.showUnits).toEqual(true);
+    expect(widget.wrapWords).toEqual(true);
   });
 
   const readbackPrecisionUnits = `

--- a/src/ui/widgets/EmbeddedDisplay/parser.ts
+++ b/src/ui/widgets/EmbeddedDisplay/parser.ts
@@ -162,6 +162,11 @@ export function parseWidget(
   if (widgetDescription.showUnits === undefined) {
     widgetDescription.showUnits = true;
   }
+  // Default to true if wrapWords is not defined.
+  // Applicable to BOB files.
+  if (widgetDescription.wrapWords === undefined) {
+    widgetDescription.wrapWords = true;
+  }
 
   return widgetDescription;
 }


### PR DESCRIPTION
Text was not getting wrapped in label widgets parsed from a BOB file. This is because by default Phoebus assumes that the `wrap_words` property is `true` and in this case does not include it in the widget definition in the BOB file. I.e. it only explicitly includes the property if it is `false`.
CS-Studio always provides this property (whether it is true or false). If it is missing from a CSS widget, then CSS defaults it to false, however I believe the strategy going forward is to prioritise Phoebus behaviour (which would be to set it true).

Also updated tests to make sure this is parsed correctly.

Before:
![no_wrap](https://github.com/dls-controls/cs-web-lib/assets/45264327/4e976581-6abe-4069-862c-9b251a4da11f)
After:
![wrap](https://github.com/dls-controls/cs-web-lib/assets/45264327/a4cb466b-1635-4bb6-a417-db6f8309b419)
