### PR TITLE
Add graphics widget macros

### DIFF
--- a/src/ui/hooks/useMacros.ts
+++ b/src/ui/hooks/useMacros.ts
@@ -62,12 +62,15 @@ export function useMacros<P extends MacroProps>(props: P): AnyProps {
   const globalMacros = useSelector(
     (state: CsState): MacroMap => state.globalMacros
   );
+  // In Phoebus, some components e.g. Shape have a macros field
+  const propMacros = props.macros;
   const allMacros = {
     ...globalMacros, // lower priority
     ...displayMacros, // higher priority
     // Temporary special case for pv_name in macros.
     pvName: props.pvName?.name || "",
-    pv_name: props.pvName?.name || ""
+    pv_name: props.pvName?.name || "",
+    ...propMacros
   };
   return recursiveResolve(props, allMacros);
 }

--- a/src/ui/widgets/Arc/arc.tsx
+++ b/src/ui/widgets/Arc/arc.tsx
@@ -6,13 +6,15 @@ import {
   BoolPropOpt,
   InferWidgetProps,
   ColorPropOpt,
-  IntPropOpt
+  IntPropOpt,
+  MacrosPropOpt
 } from "../propTypes";
 import classes from "./arc.module.css";
 import { Color } from "../../../types";
 import { WIDGET_DEFAULT_SIZES } from "../EmbeddedDisplay/bobParser";
 
 const ArcProps = {
+  macros: MacrosPropOpt,
   width: IntPropOpt,
   height: IntPropOpt,
   backgroundColor: ColorPropOpt,

--- a/src/ui/widgets/Ellipse/ellipse.tsx
+++ b/src/ui/widgets/Ellipse/ellipse.tsx
@@ -7,7 +7,8 @@ import {
   InferWidgetProps,
   BorderPropOpt,
   ColorPropOpt,
-  IntPropOpt
+  IntPropOpt,
+  MacrosPropOpt
 } from "../propTypes";
 import { Color } from "../../../types/color";
 import classes from "./ellipse.module.css";
@@ -23,6 +24,7 @@ export type FillOptions = {
 };
 
 export const EllipseProps = {
+  macros: MacrosPropOpt,
   gradient: BoolPropOpt,
   bgGradientColor: ColorPropOpt,
   fgGradientColor: ColorPropOpt,

--- a/src/ui/widgets/EmbeddedDisplay/bobParser.ts
+++ b/src/ui/widgets/EmbeddedDisplay/bobParser.ts
@@ -256,7 +256,8 @@ export function parseBob(
     resize: ["resize", bobParseResizing],
     squareLed: ["square", opiParseBoolean],
     formatType: ["format", bobParseFormatType],
-    stretchToFit: ["stretch_image", opiParseBoolean]
+    stretchToFit: ["stretch_image", opiParseBoolean],
+    macros: ["macros", opiParseMacros]
   };
 
   const complexParsers = {

--- a/src/ui/widgets/EmbeddedDisplay/opiParser.ts
+++ b/src/ui/widgets/EmbeddedDisplay/opiParser.ts
@@ -274,7 +274,7 @@ export const opiParseRules = (
       const pvs = pvArray.map((pv: ElementCompact) => {
         return {
           pvName: opiParsePvName(pv, defaultProtocol),
-          trigger: pv._attributes?.trig === "true"
+          trigger: isOpiFile ? pv._attributes?.trig === "true" : true
         };
       });
       const expArray = toArray(ruleElement.exp);

--- a/src/ui/widgets/Image/image.tsx
+++ b/src/ui/widgets/Image/image.tsx
@@ -8,12 +8,14 @@ import {
   BoolPropOpt,
   StringPropOpt,
   FloatPropOpt,
-  FuncPropOpt
+  FuncPropOpt,
+  MacrosPropOpt
 } from "../propTypes";
 import { registerWidget } from "../register";
 
 const ImageProps = {
   imageFile: StringProp,
+  macros: MacrosPropOpt,
   alt: StringPropOpt,
   stretchToFit: BoolPropOpt,
   fitToWidth: BoolPropOpt,

--- a/src/ui/widgets/Label/label.tsx
+++ b/src/ui/widgets/Label/label.tsx
@@ -12,10 +12,12 @@ import {
   FontPropOpt,
   ColorPropOpt,
   BorderPropOpt,
-  FloatPropOpt
+  FloatPropOpt,
+  MacrosPropOpt
 } from "../propTypes";
 
 const LabelProps = {
+  macros: MacrosPropOpt,
   text: StringPropOpt,
   visible: BoolPropOpt,
   transparent: BoolPropOpt,

--- a/src/ui/widgets/Line/line.tsx
+++ b/src/ui/widgets/Line/line.tsx
@@ -8,7 +8,8 @@ import {
   ColorPropOpt,
   BoolPropOpt,
   FloatProp,
-  PointsProp
+  PointsProp,
+  MacrosPropOpt
 } from "../propTypes";
 import { registerWidget } from "../register";
 import { Color } from "../../../types/color";
@@ -19,6 +20,7 @@ const LineProps = {
   width: FloatProp,
   height: FloatProp,
   points: PointsProp,
+  macros: MacrosPropOpt,
   lineWidth: FloatPropOpt,
   backgroundColor: ColorPropOpt,
   visible: BoolPropOpt,

--- a/src/ui/widgets/Polygon/polygon.tsx
+++ b/src/ui/widgets/Polygon/polygon.tsx
@@ -8,13 +8,15 @@ import {
   ColorPropOpt,
   IntPropOpt,
   BoolPropOpt,
-  PointsPropOpt
+  PointsPropOpt,
+  MacrosPropOpt
 } from "../propTypes";
 import { Point } from "../../../types/points";
 import { Color } from "../../../types";
 import { WIDGET_DEFAULT_SIZES } from "../EmbeddedDisplay/bobParser";
 
 const PolygonProps = {
+  macros: MacrosPropOpt,
   height: IntPropOpt,
   width: IntPropOpt,
   border: BorderPropOpt,

--- a/src/ui/widgets/Shape/shape.tsx
+++ b/src/ui/widgets/Shape/shape.tsx
@@ -9,13 +9,15 @@ import {
   ColorPropOpt,
   PvPropOpt,
   IntPropOpt,
-  StringOrNumPropOpt
+  StringOrNumPropOpt,
+  MacrosPropOpt
 } from "../propTypes";
 import { Border, Color } from "../../../types";
 import { WIDGET_DEFAULT_SIZES } from "../EmbeddedDisplay/bobParser";
 
 const ShapeProps = {
   pvName: PvPropOpt,
+  macros: MacrosPropOpt,
   width: StringOrNumPropOpt,
   height: StringOrNumPropOpt,
   shapeTransform: StringPropOpt,


### PR DESCRIPTION
Phoebus now longer has a `pv_name` field on Graphics widgets Arc, Ellipse, Image, Label, Polyline, Polygon and Rectangle. This has been replaced by a `macros` field, which can be used to specify `pv_name` or other fields (if needed for rules such as changing background colour). I've added the macros field into these widgets, and also ensured these macros get parsed with the others.

I tested this with some widgets that looked like this:
```
<widget type="rectangle" version="2.0.0">
    <name>EDM Rectangle</name>
    <macros>
      <pv_name>PV NAME HERE</pv_name>
    </macros>
    <width>50</width>
    <height>50</height>
    <line_width>0</line_width>
    <line_color>
      <color name="Black" red="0" green="0" blue="0">
      </color>
    </line_color>
    <background_color>
      <color red="0" green="224" blue="0">
      </color>
    </background_color>
    <rules>
      <rule name="background_color_machineStatusRule" prop_id="background_color" out_exp="false">
        <exp bool_exp="pv0== 1">
          <value>
            <color red="0" green="224" blue="0">
            </color>
          </value>
        </exp>
        <exp bool_exp="true">
          <value>
            <color red="255" green="0" blue="0">
            </color>
          </value>
        </exp>
        <pv_name>$(pv_name)</pv_name>
      </rule>
    </rules>
  </widget>
```
To ensure the macro was passed to the rules